### PR TITLE
moved include dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ import numpy
 sources=["ngmix/_gmix.c"]
 include_dirs=[numpy.get_include()]
 
-ext=Extension("ngmix._gmix", sources)
+ext=Extension("ngmix._gmix", sources, include_dirs=include_dirs)
 
 setup(name="ngmix", 
       packages=['ngmix'],
       version="0.1",
-      ext_modules=[ext],
-      include_dirs=include_dirs)
+      ext_modules=[ext])
+
+
 
 


### PR DESCRIPTION
This is the same error that we decided to fix in fitsio, where include_dirs needs to be fed to the extensions, not the setup call. 