### PR TITLE
floating point errors

### DIFF
--- a/ngmix/_gmix.c
+++ b/ngmix/_gmix.c
@@ -505,7 +505,11 @@ static int gmix_fill_cm(struct PyGMixCM*self,
     col=pars[1];
     g1=pars[2];
     g2=pars[3];
-    T=pars[4] * self->Tfactor;
+    if (pars[4] == 0.0) {
+      T = 0.0;
+    } else {
+      T=pars[4] * self->Tfactor;
+    }
     counts=pars[5];
 
     ifracdev = 1.0-self->fracdev;

--- a/ngmix/guessers.py
+++ b/ngmix/guessers.py
@@ -58,9 +58,17 @@ class TFluxGuesser(GuesserBase):
         self.fluxes=fluxes
         self.prior=prior
         self.scaling=scaling
+        
+        if T <= 0.0:
+            self.log_T = log(1.0e-10)
+        else:
+            self.log_T = log(T)
 
-        self.log_T = log(T)
-        self.log_fluxes = log(fluxes)
+        lfluxes = fluxes.copy()
+        w, = numpy.where(fluxes < 0.0)
+        if w.size > 0:
+            lfluxes[w[:]] = 1.0e-10
+        self.log_fluxes = log(lfluxes)
 
     def __call__(self, n=1, **keys):
         """
@@ -120,8 +128,16 @@ class TFluxAndPriorGuesser(GuesserBase):
         self.prior=prior
         self.scaling=scaling
 
-        self.log_T = log(T)
-        self.log_fluxes = log(fluxes)
+        if T <= 0.0:
+            self.log_T = log(1.0e-10)
+        else:
+            self.log_T = log(T)
+
+        lfluxes = fluxes.copy()
+        w, = numpy.where(fluxes < 0.0)
+        if w.size > 0:
+            lfluxes[w[:]] = 1.0e-10
+        self.log_fluxes = log(lfluxes)
 
     def __call__(self, n=1, **keys):
         """


### PR DESCRIPTION
I have put in some changes to fix floating point errors.

1. In the `C`, for cmodel fits sometimes the `T` normalization can diverge so it checks if `T` is zero anyways and if so, just sets the internal `T` to zero.
2. In the python layer, I made the guessers check before taking logs of negative or zero `T`'s or fluxes. I am clipping the values at `1e-10`. This change may have side effects.

