### PR TITLE
ENH add meds readers for ngmix obs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/ngmix/meds.py
+++ b/ngmix/meds.py
@@ -1,0 +1,246 @@
+import numpy as np
+import meds
+
+from .observation import MultiBandObsList, Observation, ObsList
+from .jacobian import Jacobian
+
+
+class MultiBandMEDS(object):
+    """Interface to MEDS objects in more than one band for ngmix.
+
+    Parameters
+    ----------
+    mlist : list of str
+        List of paths to the MEDS files.
+
+    Attributes
+    ----------
+    size : int
+        The number of objects in the MEDS files.
+
+    Methods
+    -------
+    get_mbobs_list(indices=None, weight_type='weight')
+        Get a list of `MultiBandObsList` for all or a set of objects.
+    get_mbobs(iobj, weight_type='weight')
+        Get a `MultiBandObsList` for a given object.
+    """
+    def __init__(self, mlist):
+        self.mlist = mlist
+
+    @property
+    def size(self):
+        """Number of entries in the catalog.
+        """
+        return self.mlist[0].size
+
+    def get_mbobs_list(self, indices=None, weight_type='weight'):
+        """Get a list of `MultiBandObsList` for all or a set of objects.
+
+        Parameters
+        ----------
+        indices : array-like, optional
+            The indices of the objects to return. Default of `None` returns
+            all objects.
+        weight_type: string, optional
+            Weight type. can be one of
+                'weight': the actual weight map
+                'uberseg': uberseg modified weight map
+            Default is 'weight'
+
+        Returns
+        -------
+        mbobs_list : list of ngmix.MultiBandObsList
+            The list of `MultiBandObsList`s for the requested objects.
+        """
+        if indices is None:
+            indices = np.arange(self.mlist[0].size)
+
+        list_of_obs = []
+        for iobj in indices:
+            mbobs = self.get_mbobs(iobj, weight_type=weight_type)
+            list_of_obs.append(mbobs)
+
+        return list_of_obs
+
+    def get_mbobs(self, iobj, weight_type='weight'):
+        """Get a `MultiBandObsList` for a given object.
+
+        Parameters
+        ----------
+        iobj : int
+            Index of the object.
+        weight_type: string, optional
+            Weight type. can be one of
+                'weight': the actual weight map
+                'uberseg': uberseg modified weight map
+            Default is 'weight'
+
+        Returns
+        -------
+        mbobs : ngmix.MultiBandObsList
+            A `MultiBandObsList` holding all of the observations for this
+            object.
+        """
+        mbobs = MultiBandObsList()
+
+        for m in self.mlist:
+            obslist = m.get_obslist(iobj, weight_type=weight_type)
+            mbobs.append(obslist)
+
+        return mbobs
+
+
+class MEDS(meds.MEDS):
+    def get_obslist(self, iobj, weight_type='weight'):
+        """Get an ngmix ObsList for all observations.
+
+        Parameters
+        ----------
+        iobj : int
+            Index of the object.
+        weight_type: string, optional
+            Weight type. can be one of
+                'weight': the actual weight map
+                'uberseg': uberseg modified weight map
+            Default is 'weight'
+
+        Returns
+        -------
+        obslist : ngmix.ObsList
+            An `ObsList` of all observations.
+        """
+        obslist = ObsList()
+        for icut in range(self._cat['ncutout'][iobj]):
+            obs = self.get_obs(iobj, icut, weight_type=weight_type)
+            obslist.append(obs)
+
+        if 'flux' in obs.meta:
+            obslist.meta['flux'] = obs.meta['flux']
+        if 'T' in obs.meta:
+            obslist.meta['T'] = obs.meta['T']
+        return obslist
+
+    def get_ngmix_jacobian(self, iobj, icutout):
+        """Get an ngmix.Jacobian representation
+
+        Parameters
+        ----------
+        iobj : int
+            Index of the object.
+        icutout : int
+            Index of the cutout for this object.
+
+        Returns
+        -------
+        jacob : ngmix.Jacobian
+            The `Jacobian` for the cutout.
+        """
+        jd = self.get_jacobian(iobj, icutout)
+        return Jacobian(
+            row=jd['row0'],
+            col=jd['col0'],
+            dudrow=jd['dudrow'],
+            dudcol=jd['dudcol'],
+            dvdrow=jd['dvdrow'],
+            dvdcol=jd['dvdcol'])
+
+    def get_obs(self, iobj, icutout, weight_type='weight'):
+        """Get an ngmix Observation.
+
+        Parameters
+        ----------
+        iobj : int
+            Index of the object.
+        icutout : int
+            Index of the cutout for this object.
+        weight_type: string, optional
+            Weight type. can be one of
+                'weight': the actual weight map
+                'uberseg': uberseg modified weight map
+            Default is 'weight'
+
+        Returns
+        -------
+        obs : ngmix.Observation
+            An `Observation` for this cutout.
+        """
+        im = self.get_cutout(iobj, icutout, type='image')
+        bmask = self.get_cutout(iobj, icutout, type='bmask')
+
+        if weight_type == 'uberseg':
+            wt = self.get_uberseg(iobj, icutout)
+        elif weight_type == 'cweight':
+            wt = self.get_cweight_cutout(iobj, icutout, restrict_to_seg=True)
+        elif weight_type == 'weight':
+            wt = self.get_cutout(iobj, icutout, type='weight')
+        elif weight_type == 'cseg':
+            wt = self.get_cseg_weight(iobj, icutout)
+        elif weight_type == 'cseg-canonical':
+            wt = self.get_cseg_weight(iobj, icutout, use_canonical_cen=True)
+        else:
+            raise ValueError("bad weight type '%s'" % weight_type)
+
+        jacobian = self.get_ngmix_jacobian(iobj, icutout)
+        c = self._cat
+
+        meta = dict(
+            id=c['id'][iobj],
+            index=iobj,
+            icut=icutout,
+            cutout_index=icutout,
+            file_id=c['file_id'][iobj, icutout],
+            orig_row=c['orig_row'][iobj, icutout],
+            orig_col=c['orig_col'][iobj, icutout],
+            orig_start_row=c['orig_start_row'][iobj, icutout],
+            orig_start_col=c['orig_start_col'][iobj, icutout])
+
+        if 'flux_auto' in c.dtype.names:
+            meta['flux'] = c['flux_auto'][iobj]
+        if 'x2' in c.dtype.names and 'y2' in c.dtype.names:
+            meta['T'] = c['x2'][iobj] + c['y2'][iobj]
+        if 'number' in c.dtype.names:
+            meta['number'] = c['number'][iobj]
+
+        psf_obs = self.get_psf_obs(iobj, icutout)
+        obs = Observation(
+            im,
+            weight=wt,
+            bmask=bmask,
+            meta=meta,
+            jacobian=jacobian,
+            psf=psf_obs)
+
+        return obs
+
+    def get_psf_obs(self, iobj, icutout):
+        """Get an observation of the PSF for this object.
+
+        Parameters
+        ----------
+        iobj : int
+            Index of the object.
+        icutout : int
+            Index of the cutout for this object.
+
+        Returns
+        -------
+        psf : ngmix.Observation
+            The PSF `Observation`.
+        """
+        psf_im = self.get_psf(iobj, icutout)
+
+        # FIXME: fake the noise
+        noise = psf_im.max() / 1000.0
+        weight = psf_im*0 + 1.0/noise**2
+        jacobian = self.get_ngmix_jacobian(iobj, icutout)
+
+        cen = (np.array(psf_im.shape)-1.0) / 2.0
+        jacobian.set_cen(
+            row=cen[0],
+            col=cen[1])
+
+        return Observation(
+            psf_im,
+            weight=weight,
+            jacobian=jacobian)

--- a/ngmix/meds.py
+++ b/ngmix/meds.py
@@ -122,7 +122,7 @@ class MEDS(meds.MEDS):
         return obslist
 
     def get_ngmix_jacobian(self, iobj, icutout):
-        """Get an ngmix.Jacobian representation
+        """Get an ngmix.Jacobian representation.
 
         Parameters
         ----------

--- a/ngmix/meds.py
+++ b/ngmix/meds.py
@@ -46,6 +46,11 @@ class MultiBandMEDS(object):
             Weight type. can be one of
                 'weight': the actual weight map
                 'uberseg': uberseg modified weight map
+                'cweight': weight map zeroed outside the object's seg map
+                'cseg': weight map zeroed outside of circular aperture that
+                    doesn't touch any other object.
+                'cseg-canonical': same as 'cseg' but uses the postage stamp
+                    center instead of the object's position.
             Default is 'weight'
 
         Returns
@@ -74,6 +79,11 @@ class MultiBandMEDS(object):
             Weight type. can be one of
                 'weight': the actual weight map
                 'uberseg': uberseg modified weight map
+                'cweight': weight map zeroed outside the object's seg map
+                'cseg': weight map zeroed outside of circular aperture that
+                    doesn't touch any other object.
+                'cseg-canonical': same as 'cseg' but uses the postage stamp
+                    center instead of the object's position.
             Default is 'weight'
 
         Returns
@@ -103,6 +113,11 @@ class MEDS(meds.MEDS):
             Weight type. can be one of
                 'weight': the actual weight map
                 'uberseg': uberseg modified weight map
+                'cweight': weight map zeroed outside the object's seg map
+                'cseg': weight map zeroed outside of circular aperture that
+                    doesn't touch any other object.
+                'cseg-canonical': same as 'cseg' but uses the postage stamp
+                    center instead of the object's position.
             Default is 'weight'
 
         Returns
@@ -158,6 +173,11 @@ class MEDS(meds.MEDS):
             Weight type. can be one of
                 'weight': the actual weight map
                 'uberseg': uberseg modified weight map
+                'cweight': weight map zeroed outside the object's seg map
+                'cseg': weight map zeroed outside of circular aperture that
+                    doesn't touch any other object.
+                'cseg-canonical': same as 'cseg' but uses the postage stamp
+                    center instead of the object's position.
             Default is 'weight'
 
         Returns

--- a/ngmix/medsreaders.py
+++ b/ngmix/medsreaders.py
@@ -1,5 +1,5 @@
 import numpy as np
-import meds
+from meds import MEDS as _MEDS
 
 from .observation import MultiBandObsList, Observation, ObsList
 from .jacobian import Jacobian
@@ -101,7 +101,7 @@ class MultiBandMEDS(object):
         return mbobs
 
 
-class MEDS(meds.MEDS):
+class MEDS(_MEDS):
     def get_obslist(self, iobj, weight_type='weight'):
         """Get an ngmix ObsList for all observations.
 

--- a/ngmix/medsreaders.py
+++ b/ngmix/medsreaders.py
@@ -10,8 +10,8 @@ class MultiBandMEDS(object):
 
     Parameters
     ----------
-    mlist : list of str
-        List of paths to the MEDS files.
+    mlist : list of `ngmix.medsreaders.NGMixMEDS` objects
+        List of the `NGMixMEDS` objects for each band.
 
     Attributes
     ----------
@@ -101,7 +101,7 @@ class MultiBandMEDS(object):
         return mbobs
 
 
-class MEDS(_MEDS):
+class NGMixMEDS(_MEDS):
     def get_obslist(self, iobj, weight_type='weight'):
         """Get an ngmix ObsList for all observations.
 

--- a/ngmix/medsreaders.py
+++ b/ngmix/medsreaders.py
@@ -5,8 +5,8 @@ from .observation import MultiBandObsList, Observation, ObsList
 from .jacobian import Jacobian
 
 
-class MultiBandMEDS(object):
-    """Interface to MEDS objects in more than one band for ngmix.
+class MultiBandNGMixMEDS(object):
+    """Interface to NGMixMEDS objects in more than one band.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR has MEDS readers subclassed to output ngmix observations. I think this is the right spot for them as opposed to the MEDS repo (i.e., if you need the ngmix stuff, then you have ngmix installed).