### PR TITLE
GalSim rendering T-clip fix and passing `gsparams`

### DIFF
--- a/ngmix/gmix.py
+++ b/ngmix/gmix.py
@@ -727,7 +727,7 @@ class GMix(object):
 
             sigma_round = sqrt(Tround/2.0)
 
-            gsobj = galsim.Gaussian(flux=flux, sigma=sigma_round)
+            gsobj = galsim.Gaussian(flux=flux, sigma=sigma_round, gsparams=gsparams)
 
             gsobj = gsobj.shear(g1=g1, g2=g2)
 

--- a/ngmix/gmix.py
+++ b/ngmix/gmix.py
@@ -670,7 +670,7 @@ class GMix(object):
         self._pars = zeros(self._npars)
         self._data = zeros(self._ngauss, dtype=_gauss2d_dtype)
 
-    def make_galsim_object(self, Tmin=0.001):
+    def make_galsim_object(self, Tmin=1e-6, gsparams=None):
         """
         make a galsim representation for the gaussian mixture
 
@@ -684,8 +684,22 @@ class GMix(object):
             Minimum size for gaussians.  Galsim doesn't allow objects
             with less than zero size because when convolving it renders
             the object
+        gsparams: GSParams or dict, optional
+            A GSParams object (or dict convertable to one) that sets
+            certain useful parameters for GalSim renderings (e.g.
+            a larger maximum FFT size)
         """
+
         import galsim
+
+        if gsparams and (type(gsparams) is not galsim._galsim.GSParams):
+            if isinstance(gsparams, dict):
+                # Convert to actual gsparams object
+                gsparams = galsim.GSParams(**gsparams)
+            else:
+                raise TypeError('Only `dict` and `galsim.GSParam` types allowed'
+                                ' for gsparams; input has type of {}.'
+                                .format(type(gsparams)))
 
         data = self.get_data()
 
@@ -693,6 +707,8 @@ class GMix(object):
         for i in xrange(len(self)):
             flux = data['p'][i]
             T = data['irr'][i] + data['icc'][i]
+            if T == 0: T = Tmin
+
             e1 = (data['icc'][i] - data['irr'][i])/T
             e2 = 2.0*data['irc'][i]/T
 

--- a/ngmix/gmix.py
+++ b/ngmix/gmix.py
@@ -692,7 +692,7 @@ class GMix(object):
 
         import galsim
 
-        if gsparams and (type(gsparams) is not galsim._galsim.GSParams):
+        if (gsparams is not None) and (not isinstance(gsparams, galsim.GSParams)):
             if isinstance(gsparams, dict):
                 # Convert to actual gsparams object
                 gsparams = galsim.GSParams(**gsparams)
@@ -707,7 +707,8 @@ class GMix(object):
         for i in xrange(len(self)):
             flux = data['p'][i]
             T = data['irr'][i] + data['icc'][i]
-            if T == 0: T = Tmin
+            if T == 0:
+                T = Tmin
 
             e1 = (data['icc'][i] - data['irr'][i])/T
             e2 = 2.0*data['irc'][i]/T


### PR DESCRIPTION
This PR attempts to solve 3 issues related to Balrog:
1. The T-clipping added in 310d7a6b7c60aeca2e17e975d47c15ad49ff5a53 to `make_galsim_object()` does not actually avoid GalSim rendering failures.
2. The default clipping of `Tmin=0.001` is too large.
3. There is no existing way to pass `gsparams` to the created `GSObject`.

The problem with (1) is that the size clipping is done on `Tround` rather than the individual Gaussian `T`s. This is an issue for `TdByTe=0` objects which store zero values for the covariance matrix; e.g.
```
p: 0.09917 row: 0 col: 0 irr: -1.087e-05 irc: 3.355e-08 icc: -1.107e-05
p: 1.279 row: 0 col: 0 irr: -7.994e-05 irc: 2.468e-07 icc: -8.141e-05
p: 8.577 row: 0 col: 0 irr: -0.0003499 irc: 1.08e-06 icc: -0.0003564
p: 35.09 row: 0 col: 0 irr: -0.001195 irc: 3.69e-06 icc: -0.001217
p: 73.24 row: 0 col: 0 irr: -0.003514 irc: 1.085e-05 icc: -0.003579
p: 42.69 row: 0 col: 0 irr: -0.009525 irc: 2.94e-05 icc: -0.0097
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
p: 0 row: 0 col: 0 irr: -0 irc: 0 icc: -0
```
For objects like the above with `TdByTe=0` and `fracdev=0`, the T-clipping should solve the issue as there is no actual flux being placed anyway. However, roughly 5% of `TdByTe=0` objects in the DES deep-field sample I am using have `fracdev>0` and so sometimes have significant flux in the zero-sized Dev component Gaussians:
```
p: 0.9576 row: 0 col: 0 irr: 0.3722 irc: 0.1636 icc: 0.1422
p: 12.35 row: 0 col: 0 irr: 2.738 irc: 1.203 icc: 1.046
p: 82.83 row: 0 col: 0 irr: 11.99 irc: 5.267 icc: 4.579
p: 338.9 row: 0 col: 0 irr: 40.94 irc: 17.99 icc: 15.64
p: 707.3 row: 0 col: 0 irr: 120.4 irc: 52.9 icc: 45.99
p: 412.3 row: 0 col: 0 irr: 326.2 irc: 143.4 icc: 124.6
p: 0.5378 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 3.641 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 17.18 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 62.54 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 186.2 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 465.7 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 983.5 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 1727 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 2410 row: 0 col: 0 irr: 0 irc: 0 icc: 0
p: 2381 row: 0 col: 0 irr: 0 irc: 0 icc: 0
```
It is less clear to me what to do with these objects (even if <0.5% of the full sample) and suggestions are welcome.

For (2), see Balrog-produced MEDS cutouts - ngmix rendering residual plots [here](https://github.com/sweverett/Balrog-GalSim/issues/58). Issue was resolved for `Tmin=1e-5` but being a bit more conservative here.