### PR TITLE
fitters/runners/bootstrappers return FitModel/Result objects

### DIFF
--- a/examples/em/em_1gauss.py
+++ b/examples/em/em_1gauss.py
@@ -15,9 +15,10 @@ def main():
     # use a psf guesser
     guesser = ngmix.guessers.GMixPSFGuesser(rng=rng, ngauss=1)
     guess = guesser(obs=obs)
-    fitter = ngmix.em.fit_em(obs=obs, guess=guess)
+    res = ngmix.em.fit_em(obs=obs, guess=guess)
 
-    gmfit = fitter.get_gmix()
+    gmfit = res.get_gmix()
+
     print('true gm:')
     print(gm)
     print('fit gm:')
@@ -29,7 +30,7 @@ def main():
         except ImportError:
             from espy import images
 
-        imfit = fitter.make_image()
+        imfit = res.make_image()
 
         images.compare_images(obs.image, imfit)
 

--- a/examples/em/em_2gauss.py
+++ b/examples/em/em_2gauss.py
@@ -15,9 +15,9 @@ def main():
     guess = gm.copy()
     randomize_gmix(rng=rng, gmix=guess, pixel_scale=obs.jacobian.scale)
 
-    fitter = ngmix.em.fit_em(obs=obs, guess=guess)
+    res = ngmix.em.fit_em(obs=obs, guess=guess)
 
-    gmfit = fitter.get_gmix()
+    gmfit = res.get_gmix()
     print('true gm:')
     print(gm)
     print('fit gm:')
@@ -29,7 +29,7 @@ def main():
         except ImportError:
             from espy import images
 
-        imfit = fitter.make_image()
+        imfit = res.make_image()
 
         images.compare_images(obs.image, imfit)
 

--- a/examples/em/em_2gauss_psf.py
+++ b/examples/em/em_2gauss_psf.py
@@ -17,9 +17,9 @@ def main():
     guess = gm.copy()
     randomize_gmix(rng=rng, gmix=guess, pixel_scale=obs.jacobian.scale)
 
-    fitter = ngmix.em.fit_em(obs=obs, guess=guess)
+    res = ngmix.em.fit_em(obs=obs, guess=guess)
 
-    gmfit = fitter.get_gmix()
+    gmfit = res.get_gmix()
     print('true gm:')
     print(gm)
     print('fit gm:')
@@ -31,7 +31,7 @@ def main():
         except ImportError:
             from espy import images
 
-        imfit = fitter.make_image()
+        imfit = res.make_image()
 
         images.compare_images(obs.image, imfit)
 

--- a/examples/metacal/metacal.py
+++ b/examples/metacal/metacal.py
@@ -72,8 +72,7 @@ def main():
 
         obs = make_data(rng=rng, noise=args.noise, shear=shear_true)
 
-        boot.go(obs)
-        resdict = boot.get_result()
+        resdict, obsdict = boot.go(obs)
 
         gvals[i, :] = resdict['noshear']['e']
 

--- a/examples/metacal/metacal_select.py
+++ b/examples/metacal/metacal_select.py
@@ -71,12 +71,10 @@ def main():
     for i in progress(args.ntrial, miniters=10):
         obs = make_data(rng=rng, noise=args.noise, shear=shear_true)
 
-        boot.go(obs)
-        res = boot.result
-        obsdict = boot.obsdict
+        resdict, obsdict = boot.go(obs)
 
         # keep any that pass the flags
-        for stype, sres in res.items():
+        for stype, sres in resdict.items():
             if sres['flags'] == 0:
                 st = make_struct(res=sres, obs=obsdict[stype], shear_type=stype)
                 dlist.append(st)

--- a/ngmix/__init__.py
+++ b/ngmix/__init__.py
@@ -44,6 +44,7 @@ from .gexceptions import (
 )
 
 from . import fitting
+from .fitting import *
 from . import simplex
 
 from . import galsimfit

--- a/ngmix/admom.py
+++ b/ngmix/admom.py
@@ -50,8 +50,56 @@ def run_admom(
         Ttol=Ttol,
         rng=rng,
     )
-    am.go(obs=obs, guess=guess)
-    return am
+    return am.go(obs=obs, guess=guess)
+
+
+class AdmomResult(dict):
+    def __init__(self, obs, result):
+        self._obs = obs
+        self.update(result)
+
+    def get_gmix(self):
+        """
+        get a gmix representing the best fit, normalized
+        """
+        if self['flags'] != 0:
+            raise RuntimeError('cannot create gmix, fit failed')
+
+        pars = self['pars'].copy()
+        pars[5] = 1.0
+
+        e1 = pars[2]/pars[4]
+        e2 = pars[3]/pars[4]
+
+        g1, g2 = e1e2_to_g1g2(e1, e2)
+        pars[2] = g1
+        pars[3] = g2
+
+        return GMixModel(pars, "gauss")
+
+    def make_image(self):
+        """
+        Get an image of the best fit mixture
+
+        Returns
+        -------
+        image: array
+            Image of the model, including the PSF if a psf was sent
+        """
+        if self['flags'] != 0:
+            raise RuntimeError('cannot create image, fit failed')
+
+        obs = self._obs
+        jac = obs.jacobian
+
+        gm = self.get_gmix()
+        gm.set_flux(obs.image.sum() * jac.scale**2)
+
+        im = gm.make_image(
+            obs.image.shape,
+            jacobian=jac,
+        )
+        return im
 
 
 class Admom(object):
@@ -82,8 +130,7 @@ class Admom(object):
                  shiftmax=DEFAULT_SHIFTMAX,
                  etol=DEFAULT_ETOL,
                  Ttol=DEFAULT_TTOL,
-                 rng=None,
-                 **unused_keys):
+                 rng=None):
 
         self._set_conf(maxiter, shiftmax, etol, Ttol)
 
@@ -106,7 +153,6 @@ class Admom(object):
 
         if not isinstance(obs, Observation):
             raise ValueError("input obs must be an Observation")
-        self._obs = obs
 
         guess_gmix = self._get_guess(obs=obs, guess=guess)
 
@@ -120,54 +166,9 @@ class Admom(object):
             ares,
         )
 
-        self.result = get_result(ares)
+        result = get_result(ares)
 
-    def get_result(self):
-        """
-        get the result
-        """
-        if not hasattr(self, 'result'):
-            raise RuntimeError("run go() first")
-
-        return self.result
-
-    def get_gmix(self):
-        """
-        get a gmix representing the best fit, normalized
-        """
-
-        pars = self.result['pars'].copy()
-        pars[5] = 1.0
-
-        e1 = pars[2]/pars[4]
-        e2 = pars[3]/pars[4]
-
-        g1, g2 = e1e2_to_g1g2(e1, e2)
-        pars[2] = g1
-        pars[3] = g2
-
-        return GMixModel(pars, "gauss")
-
-    def make_image(self):
-        """
-        Get an image of the best fit mixture
-
-        Returns
-        -------
-        image: array
-            Image of the model, including the PSF if a psf was sent
-        """
-        obs = self._obs
-        jac = obs.jacobian
-
-        gm = self.get_gmix()
-        gm.set_flux(obs.image.sum() * jac.scale**2)
-
-        im = gm.make_image(
-            obs.image.shape,
-            jacobian=jac,
-        )
-        return im
+        return AdmomResult(obs=obs, result=result)
 
     def _get_guess(self, obs, guess):
         if isinstance(guess, GMix):

--- a/ngmix/admom.py
+++ b/ngmix/admom.py
@@ -54,6 +54,18 @@ def run_admom(
 
 
 class AdmomResult(dict):
+    """
+    Represent a fit using adaptive moments, and generate images and mixtures
+    for the best fit
+
+    Parameters
+    ----------
+    obs: observation(s)
+        Observation, ObsList, or MultiBandObsList
+    result: dict
+        the basic fit result, to bad added to this object's keys
+    """
+
     def __init__(self, obs, result):
         self._obs = obs
         self.update(result)

--- a/ngmix/bootstrap.py
+++ b/ngmix/bootstrap.py
@@ -48,7 +48,7 @@ class Bootstrapper(object):
         obs: ngmix Observation(s)
             Observation, ObsList, or MultiBandObsList
         """
-        bootstrap(
+        return bootstrap(
             obs=obs,
             runner=self.runner,
             psf_runner=self.psf_runner,
@@ -61,19 +61,6 @@ class Bootstrapper(object):
         get a reference to the fitter
         """
         return self.runner.fitter
-
-    def get_result(self):
-        """
-        get the result dict for the last fit
-        """
-        return self.fitter.get_result()
-
-    @property
-    def result(self):
-        """
-        get the result dict for the last fit
-        """
-        return self.get_result()
 
 
 def bootstrap(
@@ -111,7 +98,7 @@ def bootstrap(
         if ignore_failed_psf:
             obs = remove_failed_psf_obs(obs=obs)
 
-    runner.go(obs=obs)
+    return runner.go(obs=obs)
 
 
 def remove_failed_psf_obs(obs):

--- a/ngmix/em.py
+++ b/ngmix/em.py
@@ -69,9 +69,7 @@ def fit_em(obs, guess, sky=None, fixcen=False, fluxonly=False, **kws):
     else:
         fitter = GMixEM(**kws)
 
-    fitter.go(obs=obs, guess=guess, sky=sky)
-
-    return fitter
+    return fitter.go(obs=obs, guess=guess, sky=sky)
 
 
 def prep_obs(obs):
@@ -150,8 +148,9 @@ class EMResult(dict):
     def __init__(self, obs, result, gm=None, gm_conv=None):
         self._obs = obs
         self.update(result)
-        if gm is not None:
+        if gm is not None and gm_conv is not None:
             self._gm = gm
+            self._gm_conv = gm_conv
 
     def has_gmix(self):
         """

--- a/ngmix/em.py
+++ b/ngmix/em.py
@@ -133,37 +133,25 @@ def prep_image(im0):
     return im, sky
 
 
-class GMixEM(object):
+class EMResult(dict):
     """
-    Fit an image with a gaussian mixture using the EM algorithm
+    Class to represent an EM model fit
 
-    Parameters
+    parameters
     ----------
-    miniter: number, optional
-        The minimum number of iterations, default 40
-    maxiter: number, optional
-        The maximum number of iterations, default 500
-    tol: number, optional
-        The fractional change in the log likelihood that implies convergence,
-        default 0.001
-    vary_sky: bool
-        If True, fit for the sky level
+    obs: Observation
+        An ngmix.Observation object.  This must already have been run through
+        prep_obs to make sure there are no pixels less than zero
+    guess: GMix
+        A gaussian mixture (GMix or child class) representing a starting
+        guess for the algorithm.  This should be *before* psf convolution.
     """
-    def __init__(self,
-                 miniter=40,
-                 maxiter=500,
-                 tol=DEFAULT_TOL,
-                 vary_sky=False):
 
-        self.miniter = miniter
-        self.maxiter = maxiter
-        self.tol = tol
-        self.vary_sky = vary_sky
-
-        self._sums = None
-        self._result = None
-
-        self._set_runner()
+    def __init__(self, obs, result, gm=None, gm_conv=None):
+        self._obs = obs
+        self.update(result)
+        if gm is not None:
+            self._gm = gm
 
     def has_gmix(self):
         """
@@ -204,29 +192,6 @@ class GMixEM(object):
 
         return self._gm_conv.copy()
 
-    def get_result(self):
-        """
-        Get a dict with stats about the processing
-
-        Returns
-        ----------
-        result: dict
-            Some information about the processing, including
-            flags: int
-                Any processing flags
-            numiter: int
-                Number of iterations
-            fdiff: float
-                Fractional difference in the log likelihood between
-                the last two iterations
-            sky: float
-                Value of sky, may be different than input when the sky
-                is fit for
-            message: str
-                A string describing how the processing when, e.g. OK or maxit
-        """
-        return self._result
-
     def make_image(self):
         """
         Get an image of the best fit mixture
@@ -241,6 +206,35 @@ class GMixEM(object):
             self._obs.image.shape,
             jacobian=self._obs.jacobian,
         )
+
+
+class GMixEM(object):
+    """
+    Fit an image with a gaussian mixture using the EM algorithm
+
+    Parameters
+    ----------
+    miniter: number, optional
+        The minimum number of iterations, default 40
+    maxiter: number, optional
+        The maximum number of iterations, default 500
+    tol: number, optional
+        The fractional change in the log likelihood that implies convergence,
+        default 0.001
+    vary_sky: bool
+        If True, fit for the sky level
+    """
+    def __init__(self,
+                 miniter=40,
+                 maxiter=500,
+                 tol=DEFAULT_TOL,
+                 vary_sky=False):
+
+        self.miniter = miniter
+        self.maxiter = maxiter
+        self.tol = tol
+        self.vary_sky = vary_sky
+        self._set_runner()
 
     def go(self, obs, guess, sky=None):
         """
@@ -259,36 +253,32 @@ class GMixEM(object):
             sky such that there are no negative pixels.
         """
 
-        if hasattr(self, '_gm'):
-            del self._gm
-            del self._gm_conv
-
         assert isinstance(obs, Observation), (
             'input obs must be an instance of Observation'
         )
 
         if sky is None:
-            obs, sky = prep_obs(obs)
-
-        self._obs = obs
+            obs_sky, sky = prep_obs(obs)
+        else:
+            obs_sky = obs
 
         # makes a copy
-        if not obs.has_psf() or not obs.psf.has_gmix():
+        if not obs_sky.has_psf() or not obs_sky.psf.has_gmix():
             logger.debug('NO PSF SET')
             gmix_psf = GMixModel([0., 0., 0., 0., 0., 1.0], 'gauss')
         else:
-            gmix_psf = obs.psf.gmix
+            gmix_psf = obs_sky.psf.gmix
             gmix_psf.set_flux(1.0)
 
-        conf = self._make_conf()
+        conf = self._make_conf(obs_sky)
         conf['sky'] = sky
 
-        gm = guess.copy()
-        gm_conv = gm.convolve(gmix_psf)
+        gm_to_fit = guess.copy()
+        gm_conv_to_fit = gm_to_fit.convolve(gmix_psf)
 
-        sums = self._make_sums(len(gm))
+        sums = self._make_sums(len(gm_to_fit))
 
-        pixels = obs.pixels.copy()
+        pixels = obs_sky.pixels.copy()
 
         if np.any(pixels['ierr'] <= 0.0):
             fill_zero_weight = True
@@ -301,16 +291,16 @@ class GMixEM(object):
                 conf,
                 pixels,
                 sums,
-                gm.get_data(),
+                gm_to_fit.get_data(),
                 gmix_psf.get_data(),
-                gm_conv.get_data(),
+                gm_conv_to_fit.get_data(),
                 fill_zero_weight=fill_zero_weight,
             )
 
-            pars = gm.get_full_pars()
-            pars_conv = gm_conv.get_full_pars()
-            self._gm = GMix(pars=pars)
-            self._gm_conv = GMix(pars=pars_conv)
+            pars = gm_to_fit.get_full_pars()
+            pars_conv = gm_conv_to_fit.get_full_pars()
+            gm = GMix(pars=pars)
+            gm_conv = GMix(pars=pars_conv)
 
             if numiter >= self.maxiter:
                 flags = EM_MAXITER
@@ -327,6 +317,8 @@ class GMixEM(object):
             }
 
         except (GMixRangeError, ZeroDivisionError) as err:
+            gm = None
+            gm_conv = None
             message = str(err)
             logger.info(message)
             result = {
@@ -334,7 +326,7 @@ class GMixEM(object):
                 'message': message,
             }
 
-        self._result = result
+        return EMResult(obs=obs, result=result, gm=gm, gm_conv=gm_conv)
 
     def _make_sums(self, ngauss):
         """
@@ -342,7 +334,7 @@ class GMixEM(object):
         """
         return np.zeros(ngauss, dtype=_sums_dtype)
 
-    def _make_conf(self):
+    def _make_conf(self, obs):
         """
         make the sum structure
         """
@@ -352,7 +344,7 @@ class GMixEM(object):
         conf['tol'] = self.tol
         conf['miniter'] = self.miniter
         conf['maxiter'] = self.maxiter
-        conf['pixel_scale'] = self._obs.jacobian.scale
+        conf['pixel_scale'] = obs.jacobian.scale
         conf['vary_sky'] = self.vary_sky
 
         return conf

--- a/ngmix/em.py
+++ b/ngmix/em.py
@@ -133,7 +133,8 @@ def prep_image(im0):
 
 class EMResult(dict):
     """
-    Class to represent an EM model fit
+    Class to represent an EM model fit and generate images and gaussian
+    mixtures for the best fit
 
     parameters
     ----------

--- a/ngmix/fitting.py
+++ b/ngmix/fitting.py
@@ -572,7 +572,7 @@ class TemplateFluxFitModel(dict):
 
         self.normalize_psf = normalize_psf
 
-        self.model_name = "template"
+        self['model'] = 'template'
         self.npars = 1
         self._set_obs(obs)
 
@@ -634,7 +634,6 @@ class TemplateFluxFitModel(dict):
                 flags |= BAD_VAR
 
         result = {
-            "model": self.model_name,
             "flags": flags,
             "chi2per": chi2per,
             "dof": dof,

--- a/ngmix/fitting.py
+++ b/ngmix/fitting.py
@@ -2,6 +2,7 @@
 - todo
     - remove old unused fitters
 """
+import copy
 import numpy as np
 from numpy import diag, sqrt
 from pprint import pformat
@@ -29,7 +30,539 @@ from .defaults import PDEF, CDEF, LOWVAL, BIGVAL
 LOGGER = logging.getLogger(__name__)
 
 
-class FitterBase(object):
+class FitModelBase(dict):
+    def __init__(self, obs, model, prior=None):
+
+        self.prior = prior
+        self.model = gmix.get_model_num(model)
+        self.model_name = gmix.get_model_name(self.model)
+        self['model'] = self.model_name
+
+        self._set_obs(obs)
+        self._set_totpix()
+        self._set_npars()
+
+    def get_gmix(self, band=0):
+        """
+        Get a gaussian mixture at the fit parameter set, which
+        definition depends on the sub-class
+
+        Parameters
+        ----------
+        band: int, optional
+            Band index, default 0
+        """
+        pars = self.get_band_pars(pars=self["pars"], band=band)
+        return gmix.make_gmix_model(pars, self.model)
+
+    def get_convolved_gmix(self, band=0, obsnum=0):
+        """
+        get a gaussian mixture at the fit parameters, convolved by the psf if
+        fitting a pre-convolved model
+
+        Parameters
+        ----------
+        band: int, optional
+            Band index, default 0
+        obsnum: int, optional
+            Number of observation for the given band,
+            default 0
+        """
+
+        gm = self.get_gmix(band)
+
+        obs = self.obs[band][obsnum]
+        if obs.has_psf_gmix():
+            gm = gm.convolve(obs.psf.gmix)
+
+        return gm
+
+    def _set_obs(self, obs_in):
+        """
+        Input should be an Observation, ObsList, or MultiBandObsList
+        """
+
+        self.obs = get_mb_obs(obs_in)
+
+        self.nband = len(self.obs)
+        nimage = 0
+        for obslist in self.obs:
+            for obs in obslist:
+                nimage += 1
+        self.nimage = nimage
+
+    def _set_totpix(self):
+        """
+        Make sure the data are consistent.
+        """
+
+        totpix = 0
+        for obs_list in self.obs:
+            for obs in obs_list:
+                totpix += obs.pixels.size
+
+        self.totpix = totpix
+
+    def _set_npars(self):
+        """
+        nband should be set in set_lists, called before this
+        """
+        self.npars = gmix.get_model_npars(self.model) + self.nband - 1
+
+    def get_band_pars(self, pars, band):
+        """
+        get pars for the specified band
+        """
+        return get_band_pars(model=self.model_name, pars=pars, band=band)
+
+    def calc_lnprob(self, pars, more=False):
+        """
+        This is all we use for mcmc approaches, but also used generally for the
+        "set_fit_stats" method.  For the max likelihood fitter we also have a
+        _get_ydiff method
+        """
+
+        try:
+
+            # these are the log pars (if working in log space)
+            ln_priors = self._get_priors(pars)
+
+            lnprob = 0.0
+            s2n_numer = 0.0
+            s2n_denom = 0.0
+            npix = 0
+
+            self._fill_gmix_all(pars)
+            for band in range(self.nband):
+
+                obs_list = self.obs[band]
+                gmix_list = self._gmix_all[band]
+
+                for obs, gm in zip(obs_list, gmix_list):
+
+                    res = gm.get_loglike(obs, more=more)
+
+                    if more:
+                        lnprob += res["loglike"]
+                        s2n_numer += res["s2n_numer"]
+                        s2n_denom += res["s2n_denom"]
+                        npix += res["npix"]
+                    else:
+                        lnprob += res
+
+            # total over all bands
+            lnprob += ln_priors
+
+        except GMixRangeError:
+            lnprob = LOWVAL
+            s2n_numer = 0.0
+            s2n_denom = BIGVAL
+            npix = 0
+
+        if more:
+            return {
+                "lnprob": lnprob,
+                "s2n_numer": s2n_numer,
+                "s2n_denom": s2n_denom,
+                "npix": npix,
+            }
+        else:
+            return lnprob
+
+    def set_fit_result(self, result):
+        """
+        Get some fit statistics for the input pars.
+        """
+
+        self.update(result)
+
+        if self["flags"] == 0:
+            cres = self.calc_lnprob(self['pars'], more=True)
+            self.update(cres)
+
+            if self["s2n_denom"] > 0:
+                s2n = self["s2n_numer"] / sqrt(self["s2n_denom"])
+            else:
+                s2n = 0.0
+
+            chi2 = self["lnprob"] / (-0.5)
+            dof = self["npix"] - self.npars
+            chi2per = chi2 / dof
+
+            self["chi2per"] = chi2per
+            self["dof"] = dof
+            self["s2n_w"] = s2n
+            self["s2n"] = s2n
+
+    def _make_model(self, band_pars):
+        gm0 = gmix.make_gmix_model(band_pars, self.model)
+        return gm0
+
+    def _init_gmix_all(self, pars):
+        """
+        input pars are in linear space
+
+        initialize the list of lists of gaussian mixtures
+        """
+
+        if self.obs[0][0].has_psf_gmix():
+            self.dopsf = True
+        else:
+            self.dopsf = False
+
+        gmix_all0 = MultiBandGMixList()
+        gmix_all = MultiBandGMixList()
+
+        for band, obs_list in enumerate(self.obs):
+            gmix_list0 = GMixList()
+            gmix_list = GMixList()
+
+            # pars for this band, in linear space
+            band_pars = self.get_band_pars(pars=pars, band=band)
+
+            for obs in obs_list:
+                gm0 = self._make_model(band_pars)
+                if self.dopsf:
+                    psf_gmix = obs.psf.gmix
+                    gm = gm0.convolve(psf_gmix)
+                else:
+                    gm = gm0.copy()
+
+                gmix_list0.append(gm0)
+                gmix_list.append(gm)
+
+            gmix_all0.append(gmix_list0)
+            gmix_all.append(gmix_list)
+
+        self._gmix_all0 = gmix_all0
+        self._gmix_all = gmix_all
+
+    def _convolve_gmix(self, gm, gm0, psf_gmix):
+        """
+        norms get set
+        """
+        gmix_convolve_fill(gm._data, gm0._data, psf_gmix._data)
+
+    def _fill_gmix_all(self, pars):
+        """
+        input pars are in linear space
+
+        Fill the list of lists of gmix objects for the given parameters
+        """
+
+        if not self.dopsf:
+            self._fill_gmix_all_nopsf(pars)
+            return
+
+        for band, obs_list in enumerate(self.obs):
+            gmix_list0 = self._gmix_all0[band]
+            gmix_list = self._gmix_all[band]
+
+            band_pars = self.get_band_pars(pars=pars, band=band)
+
+            for i, obs in enumerate(obs_list):
+
+                psf_gmix = obs.psf.gmix
+
+                gm0 = gmix_list0[i]
+                gm = gmix_list[i]
+
+                gm0._fill(band_pars)
+                self._convolve_gmix(gm, gm0, psf_gmix)
+
+    def _fill_gmix_all_nopsf(self, pars):
+        """
+        Fill the list of lists of gmix objects for the given parameters
+        """
+
+        for band, obs_list in enumerate(self.obs):
+            gmix_list = self._gmix_all[band]
+
+            band_pars = self.get_band_pars(pars=pars, band=band)
+
+            for i, obs in enumerate(obs_list):
+
+                gm = gmix_list[i]
+
+                gm._fill(band_pars)
+
+    def _get_priors(self, pars):
+        """
+        get the sum of ln(prob) from the priors or 0.0 if
+        no priors were sent
+        """
+        if self.prior is None:
+            return 0.0
+        else:
+            return self.prior.get_lnprob_scalar(pars)
+
+    def plot_residuals(
+        self, title=None, show=False, width=1920, height=1200, **keys
+    ):
+        import images
+        import biggles
+
+        biggles.configure("screen", "width", width)
+        biggles.configure("screen", "height", height)
+
+        try:
+            self._fill_gmix_all(self["pars"])
+        except GMixRangeError as gerror:
+            print(str(gerror))
+            return None
+
+        plist = []
+        for band in range(self.nband):
+
+            band_list = []
+
+            obs_list = self.obs[band]
+            gmix_list = self._gmix_all[band]
+
+            nim = len(gmix_list)
+
+            ttitle = "band: %s" % band
+            if title is not None:
+                ttitle = "%s %s" % (title, ttitle)
+
+            for i in range(nim):
+
+                this_title = "%s cutout: %d" % (ttitle, i + 1)
+
+                obs = obs_list[i]
+                gm = gmix_list[i]
+
+                im = obs.image
+                wt = obs.weight
+                j = obs.jacobian
+
+                model = gm.make_image(im.shape, jacobian=j)
+
+                showim = im * wt
+                showmod = model * wt
+
+                sub_tab = images.compare_images(
+                    showim,
+                    showmod,
+                    show=False,
+                    label1="galaxy",
+                    label2="model",
+                    **keys
+                )
+                sub_tab.title = this_title
+
+                band_list.append(sub_tab)
+
+                if show:
+                    sub_tab.show()
+
+            plist.append(band_list)
+        return plist
+
+
+class LMFitModel(FitModelBase):
+    def __init__(self, obs, model, guess, prior=None):
+        super().__init__(obs=obs, model=model, prior=prior)
+        self._set_n_prior_pars()
+        self._set_fdiff_size()
+        self._make_pixel_list()
+
+        self._set_bounds()
+        self._setup_fit(guess)
+
+    def _setup_fit(self, guess):
+        """
+        setup the mixtures based on the initial guess
+        """
+
+        guess = np.array(guess, dtype="f8", copy=False)
+
+        npars = guess.size
+        mess = "guess has npars=%d, expected %d" % (npars, self.npars)
+        assert npars == self.npars, mess
+
+        try:
+            # this can raise GMixRangeError
+            self._init_gmix_all(guess)
+            self._make_gmix_list()
+        except ZeroDivisionError:
+            raise GMixRangeError("got zero division")
+
+    def make_image(self, band=0, obsnum=0):
+        """
+        Get an image of the best fit mixture
+
+        Returns
+        -------
+        image: array
+            Image of the model, including the PSF if a psf was sent
+        """
+        gm = self.get_convolved_gmix(band=band, obsnum=obsnum)
+        obs = self.obs[band][obsnum]
+        return gm.make_image(
+            obs.image.shape,
+            jacobian=obs.jacobian,
+        )
+
+    def _set_n_prior_pars(self):
+        # center1 + center2 + shape + T + fluxes
+        if self.prior is None:
+            self.n_prior_pars = 0
+        else:
+            self.n_prior_pars = get_lm_n_prior_pars(
+                model=self.model_name, nband=self.nband,
+            )
+
+    def _set_fdiff_size(self):
+        self.fdiff_size = self.totpix + self.n_prior_pars
+
+    @property
+    def bounds(self):
+        return copy.deepcopy(self._bounds)
+
+    def _set_bounds(self):
+        """
+        get bounds on parameters
+        """
+        self._bounds = None
+        if self.prior is not None:
+            if hasattr(self.prior, "bounds"):
+                self._bounds = self.prior.bounds
+
+    def set_fit_result(self, result):
+        """
+        set additional statistics and derived quantities
+        """
+        super().set_fit_result(result)
+
+        self._set_g()
+        self._set_T()
+        self._set_flux()
+
+    def _set_g(self):
+        self["g"] = self["pars"][2:2+2].copy()
+        self["g_cov"] = self["pars_cov"][2:2+2, 2:2+2].copy()
+
+    def _set_T(self):
+        self["T"] = self["pars"][4]
+        self["T_err"] = sqrt(self["pars_cov"][4, 4])
+
+    def _set_flux(self):
+        _set_flux(res=self, nband=self.nband)
+
+    def _make_pixel_list(self):
+        """
+        lists of references.
+        """
+        pixels_list = []
+
+        for band in range(self.nband):
+            obs_list = self.obs[band]
+            for obs in obs_list:
+                pixels_list.append(obs._pixels)
+
+        self._pixels_list = pixels_list
+
+    def _make_gmix_list(self):
+        """
+        lists of references.
+        """
+        gmix_data_list = []
+
+        for band in range(self.nband):
+
+            gmix_list = self._gmix_all[band]
+
+            for gm in gmix_list:
+                gmdata = gm.get_data()
+                gmix_data_list.append(gmdata)
+
+        self._gmix_data_list = gmix_data_list
+
+    def calc_fdiff(self, pars):
+        """
+        vector with (model-data)/error.
+
+        The npars elements contain -ln(prior)
+        """
+
+        # we cannot keep sending existing array into leastsq, don't know why
+        fdiff = np.zeros(self.fdiff_size)
+
+        try:
+
+            # all norms are set after fill
+            self._fill_gmix_all(pars)
+
+            start = self._fill_priors(pars=pars, fdiff=fdiff)
+
+            for pixels, gm in zip(self._pixels_list, self._gmix_data_list):
+                fill_fdiff(
+                    gm, pixels, fdiff, start,
+                )
+
+                start += pixels.size
+
+        except GMixRangeError:
+            fdiff[:] = LOWVAL
+
+        return fdiff
+
+    def _fill_priors(self, pars, fdiff):
+        """
+        Fill priors at the beginning of the array.
+
+        ret the position after last par
+
+        We require all the lnprobs are < 0, equivalent to
+        the peak probability always being 1.0
+
+        I have verified all our priors have this property.
+        """
+
+        if self.prior is None:
+            nprior = 0
+        else:
+            nprior = self.prior.fill_fdiff(pars, fdiff)
+
+        return nprior
+
+
+class LMCoellipFitModel(LMFitModel):
+    def __init__(self, obs, ngauss, guess, prior=None):
+        self._ngauss = ngauss
+        super().__init__(obs=obs, model='coellip', guess=guess, prior=prior)
+
+    def _set_flux(self):
+        """
+        this should be doable
+        """
+        pass
+
+    def _set_n_prior_pars(self):
+        assert self.nband == 1, "Coellip can only fit one band"
+
+        if self.prior is None:
+            self.n_prior_pars = 0
+        else:
+            ngauss = self._ngauss
+            self.n_prior_pars = 1 + 1 + 1 + ngauss + ngauss
+
+    def _set_npars(self):
+        """
+        single band, npars determined from ngauss
+        """
+        self.npars = 4 + 2 * self._ngauss
+
+    def get_band_pars(self, pars, band):
+        """
+        Get linear pars for the specified band
+        """
+
+        return pars.copy()
+
+
+class FitterBaseOld(object):
     """
     Base for other fitters
 
@@ -399,52 +932,48 @@ class FitterBase(object):
         return plist
 
 
-class TemplateFluxFitter(FitterBase):
+class FitterBase(object):
     """
-    We fix the center, so this is linear.  Just cross-correlations
-    between model and data.
+    Base for other fitters
 
-    The center of the jacobian(s) must point to a common place on the sky, and
-    if the center is input (to reset the gmix centers),) it is relative to that
-    position
+    The basic input is the Observation (or ObsList or MultiBandObsList)
 
-    Parameters
-    -----------
-    obs: Observation or ObsList
-        See ngmix.observation.Observation.  The observation should
-        have a gmix set.
-    do_psf: bool, optional
-        If True, use the gaussian mixtures in the psf observation as templates.
-        In this mode the code calculates a "psf flux".  Default False.
-    cen: 2-element sequence, optional
-        The center in sky coordinates, relative to the jacobian center(s).  If
-        not sent, the gmix (or psf gmix) object(s) in the observation(s) should
-        be set to the wanted center.  Default None.
-    normalize_psf: True or False
-        if True, then normalize PSF gmix to flux of unity, otherwise use input
-        normalization.  Default True
+    Designed to fit many images at once.  For this reason, a jacobian
+    transformation is used to put all on the same system; this is part of each
+    Observation object. For the same reason, the center of the model is
+    relative to "zero", which points to the common center used by all
+    transformation objects; the row0,col0 in pixels for each should correspond
+    to that center in the common coordinates (e.g. sky coords)
+
+    Fluxes and sizes will also be in the transformed system.
+
     """
 
-    def __init__(self, do_psf=False, cen=None, normalize_psf=True):
+    def __init__(self, model, prior=None):
 
+        self.prior = prior
+        self.model = gmix.get_model_num(model)
+        self.model_name = gmix.get_model_name(self.model)
+
+
+class TemplateFluxFitModel(dict):
+    """
+    This class represents a template flux fit model and result
+    """
+
+    def __init__(self, obs, do_psf=False, normalize_psf=True):
         self.do_psf = do_psf
-        self.cen = cen
 
         self.normalize_psf = normalize_psf
 
-        if self.cen is None:
-            self.cen_was_sent = False
-        else:
-            self.cen_was_sent = True
-
         self.model_name = "template"
         self.npars = 1
+        self._set_obs(obs)
 
-    def go(self, obs):
+    def go(self):
         """
         calculate the flux using zero-lag cross-correlation
         """
-        self._set_obs(obs)
 
         flags = 0
 
@@ -498,7 +1027,7 @@ class TemplateFluxFitter(FitterBase):
             else:
                 flags |= BAD_VAR
 
-        self._result = {
+        result = {
             "model": self.model_name,
             "flags": flags,
             "chi2per": chi2per,
@@ -506,6 +1035,7 @@ class TemplateFluxFitter(FitterBase):
             "flux": flux,
             "flux_err": flux_err,
         }
+        self.update(result)
 
     def _get_chi2(self, model, im, wt):
         """
@@ -585,7 +1115,6 @@ class TemplateFluxFitter(FitterBase):
 
     def _set_gmix_and_norms(self):
         self.use_template = False
-        cen = self.cen
         gmix_list = []
         norm_list = []
         for obs in self.obs:
@@ -598,9 +1127,6 @@ class TemplateFluxFitter(FitterBase):
                 gmix = obs.get_gmix()
                 gmix.set_flux(1.0)
 
-            if self.cen_was_sent:
-                gmix.set_cen(cen[0], cen[1])
-
             gmix_list.append(gmix)
             norm_list.append(gmix.get_flux())
 
@@ -609,8 +1135,6 @@ class TemplateFluxFitter(FitterBase):
 
     def _set_templates_and_norms(self):
         self.use_template = True
-
-        assert self.cen_was_sent is False
 
         template_list = []
         norm_list = []
@@ -674,6 +1198,38 @@ class TemplateFluxFitter(FitterBase):
         return self._npix
 
 
+class TemplateFluxFitter(FitterBase):
+    """
+    Calculate the flux for the input template.  We fix the center, so this is
+    linear.  This uses a simple cross-correlation between model and data.
+
+    The center of the jacobian(s) must point to a common place on the sky, and
+    if the center is input (to reset the gmix centers),) it is relative to that
+    position
+
+    Parameters
+    -----------
+    do_psf: bool, optional
+        If True, use the gaussian mixtures in the psf observation as templates.
+        In this mode the code calculates a "psf flux".  Default False.
+    normalize_psf: True or False
+        if True, then normalize PSF gmix to flux of unity, otherwise use input
+        normalization.  Default True
+    """
+
+    def __init__(self, do_psf=False, normalize_psf=True):
+        self.do_psf = do_psf
+        self.normalize_psf = normalize_psf
+
+    def go(self, obs):
+
+        fit_model = TemplateFluxFitModel(
+            obs=obs, do_psf=self.do_psf, normalize_psf=self.normalize_psf,
+        )
+        fit_model.go()
+        return fit_model
+
+
 _default_lm_pars = {"maxfev": 4000, "ftol": 1.0e-5, "xtol": 1.0e-5}
 
 
@@ -684,25 +1240,12 @@ class LM(FitterBase):
     """
 
     def __init__(self, model, prior=None, fit_pars=None):
-
         super().__init__(model=model, prior=prior)
 
         if fit_pars is not None:
             self.fit_pars = fit_pars.copy()
         else:
             self.fit_pars = _default_lm_pars.copy()
-
-    def _set_n_prior_pars(self):
-        # center1 + center2 + shape + T + fluxes
-        if self.prior is None:
-            self.n_prior_pars = 0
-        else:
-            self.n_prior_pars = get_lm_n_prior_pars(
-                model=self.model_name, nband=self.nband,
-            )
-
-    def _set_fdiff_size(self):
-        self.fdiff_size = self.totpix + self.n_prior_pars
 
     def go(self, obs, guess):
         """
@@ -716,181 +1259,23 @@ class LM(FitterBase):
             Array of initial parameters for the fit
         """
 
-        guess = np.array(guess, dtype="f8", copy=False)
-        self._setup_data(obs=obs, guess=guess)
-
-        self._make_lists()
-
-        bounds = self._get_bounds()
+        fit_model = self._make_fit_model(obs=obs, guess=guess)
 
         result = run_leastsq(
-            self._calc_fdiff,
-            guess,
-            self.n_prior_pars,
-            bounds=bounds,
+            fit_model.calc_fdiff,
+            guess=guess,
+            n_prior_pars=fit_model.n_prior_pars,
+            bounds=fit_model.bounds,
             **self.fit_pars
         )
 
-        result["model"] = self.model_name
-        if result["flags"] == 0:
-            result["g"] = result["pars"][2:2+2].copy()
-            result["g_cov"] = result["pars_cov"][2:2+2, 2:2+2].copy()
-            self._set_flux(result)
-            self._set_T(result)
-            stat_dict = self.get_fit_stats(result["pars"])
-            result.update(stat_dict)
+        fit_model.set_fit_result(result)
+        return fit_model
 
-        self._result = result
-
-    def _set_flux(self, res):
-        _set_flux(res=res, nband=self.nband)
-
-    def _get_bounds(self):
-        """
-        get bounds on parameters
-        """
-        bounds = None
-        if self.prior is not None:
-            if hasattr(self.prior, "bounds"):
-                bounds = self.prior.bounds
-        return bounds
-
-    run_max = go
-    run_lm = go
-
-    def _set_T(self, res):
-        res["T"] = res["pars"][4]
-        res["T_err"] = sqrt(res["pars_cov"][4, 4])
-
-    def _setup_data(self, obs, guess):
-        """
-        Set up for the fit.  We need to know the size of the fdiff array and we
-        need to initialize the mixtures
-        """
-
-        if hasattr(self, "_result"):
-            del self._result
-
-        self._set_obs(obs)
-        self._set_totpix()
-        self._set_n_prior_pars()
-        self._set_npars()
-        self._set_fdiff_size()
-
-        npars = guess.size
-        mess = "guess has npars=%d, expected %d" % (npars, self.npars)
-        assert npars == self.npars, mess
-
-        try:
-            # this can raise GMixRangeError
-            self._init_gmix_all(guess)
-        except ZeroDivisionError:
-            raise GMixRangeError("got zero division")
-
-    def make_image(self, band=0, obsnum=0):
-        """
-        Get an image of the best fit mixture
-
-        Returns
-        -------
-        image: array
-            Image of the model, including the PSF if a psf was sent
-        """
-        gm = self.get_convolved_gmix(band=band, obsnum=obsnum)
-        obs = self.obs[band][obsnum]
-        return gm.make_image(
-            obs.image.shape,
-            jacobian=obs.jacobian,
+    def _make_fit_model(self, obs, guess):
+        return LMFitModel(
+            obs=obs, model=self.model, guess=guess, prior=self.prior,
         )
-
-    def get_T_s2n(self):
-        """
-        Get the s/n of T, dealing properly
-        with logarithmic variables
-        """
-        res = self.get_result()
-        T = res["pars"][4]
-        Terr = res["pars_err"][4]
-
-        if T == 0.0 or Terr == 0.0:
-            T_s2n = 0.0
-        else:
-            T_s2n = T / Terr
-
-        return T_s2n
-
-    def _make_lists(self):
-        """
-        lists of references.
-        """
-        pixels_list = []
-        gmix_data_list = []
-
-        for band in range(self.nband):
-
-            obs_list = self.obs[band]
-            gmix_list = self._gmix_all[band]
-
-            for obs, gm in zip(obs_list, gmix_list):
-
-                gmdata = gm.get_data()
-
-                pixels_list.append(obs._pixels)
-                gmix_data_list.append(gmdata)
-
-        self._pixels_list = pixels_list
-        self._gmix_data_list = gmix_data_list
-
-    def _calc_fdiff(self, pars):
-        """
-        vector with (model-data)/error.
-
-        The npars elements contain -ln(prior)
-        """
-
-        # we cannot keep sending existing array into leastsq, don't know why
-        fdiff = np.zeros(self.fdiff_size)
-
-        try:
-
-            # all norms are set after fill
-            self._fill_gmix_all(pars)
-
-            start = self._fill_priors(pars=pars, fdiff=fdiff)
-
-            for pixels, gm in zip(self._pixels_list, self._gmix_data_list):
-                fill_fdiff(
-                    gm, pixels, fdiff, start,
-                )
-
-                start += pixels.size
-
-        except GMixRangeError:
-            fdiff[:] = LOWVAL
-
-        return fdiff
-
-    def _fill_priors(self, pars, fdiff):
-        """
-        Fill priors at the beginning of the array.
-
-        ret the position after last par
-
-        We require all the lnprobs are < 0, equivalent to
-        the peak probability always being 1.0
-
-        I have verified all our priors have this property.
-        """
-
-        if self.prior is None:
-            nprior = 0
-        else:
-            nprior = self.prior.fill_fdiff(pars, fdiff)
-
-        return nprior
-
-
-LMSimple = LM
 
 
 class LMCoellip(LM):
@@ -904,30 +1289,10 @@ class LMCoellip(LM):
         self._ngauss = ngauss
         super().__init__(model="coellip", prior=prior, fit_pars=fit_pars)
 
-    def _set_flux(self, res):
-        pass
-
-    def _set_n_prior_pars(self):
-        assert self.nband == 1, "LMCoellip can only fit one band"
-
-        if self.prior is None:
-            self.n_prior_pars = 0
-        else:
-            ngauss = self._ngauss
-            self.n_prior_pars = 1 + 1 + 1 + ngauss + ngauss
-
-    def _set_npars(self):
-        """
-        single band, npars determined from ngauss
-        """
-        self.npars = 4 + 2 * self._ngauss
-
-    def get_band_pars(self, pars, band):
-        """
-        Get linear pars for the specified band
-        """
-
-        return pars.copy()
+    def _make_fit_model(self, obs, guess):
+        return LMCoellipFitModel(
+            obs=obs, ngauss=self._ngauss, guess=guess, prior=self.prior,
+        )
 
 
 def get_band_pars(model, pars, band):

--- a/ngmix/fitting.py
+++ b/ngmix/fitting.py
@@ -31,7 +31,8 @@ LOGGER = logging.getLogger(__name__)
 
 class LMFitModel(dict):
     """
-    A class to represent a fitting model, as well as the result of the fit
+    A class to represent a fitting model, the result of the fit, as well as
+    generate images and mixtures for the best fit model
 
     Parameters
     ----------
@@ -504,8 +505,9 @@ class LMFitModel(dict):
 
 class LMCoellipFitModel(LMFitModel):
     """
-    A class to represent a fitting a coelliptical gaussians model, as well as
-    the result of the fit
+    A class to represent a fitting a coelliptical gaussians model, the result
+    of the fit, as well as generate images and mixtures for the best fit model
+
 
     Parameters
     ----------
@@ -833,7 +835,7 @@ class TemplateFluxFitter(object):
         Returns
         --------
         a dict-like which contains the result as well as functions used for the
-        fitting. The class is TemplateFluxFitModel 
+        fitting. The class is TemplateFluxFitModel
         """
         fit_model = TemplateFluxFitModel(
             obs=obs, do_psf=self.do_psf, normalize_psf=self.normalize_psf,

--- a/ngmix/galsimfit.py
+++ b/ngmix/galsimfit.py
@@ -20,14 +20,16 @@ from .gexceptions import GMixRangeError
 
 class GalsimLMFitModel(LMFitModel):
     """
-    Fit using galsim 6 parameter models
+    Represent a fitting model for fitting 6 parameter models with galsim
 
-    parameters
+    Parameters
     ----------
+    obs: observation(s)
+        Observation, ObsList, or MultiBandObsList
     model: string
         e.g. 'exp', 'spergel'
-    fit_pars: dict, optional
-        parameters for the lm fitter, e.g. maxfev, ftol, xtol
+    guess: array-like
+        starting parameters for the lm fitter
     prior: ngmix prior, optional
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
@@ -378,15 +380,15 @@ class GalsimLM(object):
     """
     Fit using galsim 6 parameter models
 
-    parameters
+    Parameters
     ----------
     model: string
         e.g. 'exp', 'spergel'
-    fit_pars: dict, optional
-        parameters for the lm fitter, e.g. maxfev, ftol, xtol
     prior: ngmix prior, optional
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
+    fit_pars: dict, optional
+        parameters for the lm fitter, e.g. maxfev, ftol, xtol
     """
 
     def __init__(self, model, prior=None, fit_pars=None):
@@ -426,14 +428,14 @@ class GalsimLM(object):
 
 class GalsimLMSpergelFitModel(GalsimLMFitModel):
     """
-    Fit using galsim 6 parameter models
+    Represent a fitting model for fitting the spergel model with galsim
 
     parameters
     ----------
-    model: string
-        e.g. 'exp', 'spergel'
-    fit_pars: dict, optional
-        parameters for the lm fitter, e.g. maxfev, ftol, xtol
+    obs: observation(s)
+        Observation, ObsList, or MultiBandObsList
+    guess: array-like
+        starting parameters for the lm fitter
     prior: ngmix prior, optional
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
@@ -489,6 +491,14 @@ class GalsimLMSpergelFitModel(GalsimLMFitModel):
 class GalsimLMSpergel(GalsimLM):
     """
     Fit the spergel profile to the input observations
+
+    Parameters
+    ----------
+    prior: ngmix prior, optional
+        For example ngmix.priors.PriorSimpleSep can
+        be used as a separable prior on center, g, size, flux.
+    fit_pars: dict, optional
+        parameters for the lm fitter, e.g. maxfev, ftol, xtol
     """
 
     def __init__(self, prior=None, fit_pars=None):
@@ -502,7 +512,17 @@ class GalsimLMSpergel(GalsimLM):
 
 class GalsimLMMoffatFitModel(GalsimLMFitModel):
     """
-    Fit the moffat profile with free beta to the input observations
+    Represent a fitting model for fitting the moffat profile with galsim
+
+    Parameters
+    ----------
+    obs: observation(s)
+        Observation, ObsList, or MultiBandObsList
+    guess: array-like
+        starting parameters for the lm fitter
+    prior: ngmix prior, optional
+        For example ngmix.priors.PriorSimpleSep can
+        be used as a separable prior on center, g, size, flux.
     """
 
     def __init__(self, obs, guess, prior=None):
@@ -557,7 +577,17 @@ class GalsimLMMoffatFitModel(GalsimLMFitModel):
 
 class GalsimLMMOffat(GalsimLM):
     """
-    Fit the spergel profile to the input observations
+    Fit a moffat model using galsim
+
+    Parameters
+    ----------
+    model: string
+        e.g. 'exp', 'spergel'
+    prior: ngmix prior, optional
+        For example ngmix.priors.PriorSimpleSep can
+        be used as a separable prior on center, g, size, flux.
+    fit_pars: dict, optional
+        parameters for the lm fitter, e.g. maxfev, ftol, xtol
     """
 
     def __init__(self, prior=None, fit_pars=None):
@@ -570,6 +600,22 @@ class GalsimLMMOffat(GalsimLM):
 
 
 class GalsimTemplateFitModel(TemplateFluxFitModel):
+    """
+    Represent a fitting model template flux fits
+
+    Parameters
+    ----------
+    obs: observation(s)
+        Observation, ObsList, or MultiBandObsList
+    model: galsim model, optional
+        A Galsim model, e.g. Exponential.  If not sent,
+        a psf flux is measured
+    draw_method: str
+        Galsim drawing method, default 'auto'
+    interp: string
+        type of interpolation when using the PSF image
+        rather than psf models.  Default lanzcos15
+    """
     def __init__(
         self,
         obs,
@@ -577,19 +623,6 @@ class GalsimTemplateFitModel(TemplateFluxFitModel):
         draw_method='auto',
         interp=observation.DEFAULT_XINTERP,
     ):
-        """
-        parameters
-        -----------
-        obs: Observation or ObsList
-            See ngmix.observation.Observation.
-        model: galsim model, optional
-            A Galsim model, e.g. Exponential.  If not sent,
-            a psf flux is measured
-
-        interp: string
-            type of interpolation when using the PSF image
-            rather than psf models.  Default lanzcos15
-        """
 
         self.galsim_model = model
 
@@ -720,6 +753,20 @@ class GalsimTemplateFitModel(TemplateFluxFitModel):
 
 
 class GalsimTemplateFluxFitter(object):
+    """
+    Calculate template fluxes using galsim
+
+    Parameters
+    ----------
+    model: galsim model, optional
+        A Galsim model, e.g. Exponential.  If not sent,
+        a psf flux is measured
+    draw_method: str
+        Galsim drawing method, default 'auto'
+    interp: string
+        type of interpolation when using the PSF image
+        rather than psf models.  Default lanzcos15
+    """
     def __init__(
         self,
         model=None,
@@ -742,6 +789,20 @@ class GalsimTemplateFluxFitter(object):
 
 
 def get_galsim_npars(model, nband):
+    """
+    get number of parameters for a galsim model
+
+    Parameters
+    ----------
+    model: str
+        Model string, e.g. exp, dev
+    nband: int
+        Number of bands
+
+    Returns
+    -------
+    number of parameters
+    """
     if model in ['exp', 'dev', 'gauss']:
         return 5 + nband
     elif model in ['spergel', 'moffat']:

--- a/ngmix/galsimfit.py
+++ b/ngmix/galsimfit.py
@@ -20,7 +20,8 @@ from .gexceptions import GMixRangeError
 
 class GalsimLMFitModel(LMFitModel):
     """
-    Represent a fitting model for fitting 6 parameter models with galsim
+    Represent a fitting model for fitting 6 parameter models with galsim, as well
+    as generate images and mixtures for the best fit model
 
     Parameters
     ----------
@@ -428,7 +429,8 @@ class GalsimLM(object):
 
 class GalsimLMSpergelFitModel(GalsimLMFitModel):
     """
-    Represent a fitting model for fitting the spergel model with galsim
+    Represent a fitting model for fitting the spergel model with galsim, as
+    well as generate images and mixtures for the best fit model
 
     parameters
     ----------
@@ -512,7 +514,8 @@ class GalsimLMSpergel(GalsimLM):
 
 class GalsimLMMoffatFitModel(GalsimLMFitModel):
     """
-    Represent a fitting model for fitting the moffat profile with galsim
+    Represent a fitting model for fitting the moffat profile with galsim, as
+    well as generate images and mixtures for the best fit model
 
     Parameters
     ----------

--- a/ngmix/galsimfit.py
+++ b/ngmix/galsimfit.py
@@ -589,11 +589,7 @@ class GalsimTemplateFitModel(TemplateFluxFitModel):
         interp: string
             type of interpolation when using the PSF image
             rather than psf models.  Default lanzcos15
-
-        TODO:
-            - try more complex wcs
         """
-
 
         self.galsim_model = model
 

--- a/ngmix/galsimfit.py
+++ b/ngmix/galsimfit.py
@@ -438,6 +438,10 @@ class GalsimLMSpergelFitModel(GalsimLMFitModel):
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
     """
+
+    def __init__(self, obs, guess, prior=None):
+        super().__init__(obs=obs, model='spergel', guess=guess, prior=prior)
+
     def _set_model_class(self):
         import galsim
 
@@ -492,17 +496,17 @@ class GalsimLMSpergel(GalsimLM):
 
     def _make_fit_model(self, obs, guess):
         return GalsimLMSpergelFitModel(
-            obs=obs, model=self.model, guess=guess, prior=self.prior,
+            obs=obs, guess=guess, prior=self.prior,
         )
 
 
-class GalsimLMMoffat(GalsimLM):
+class GalsimLMMoffatFitModel(GalsimLMFitModel):
     """
     Fit the moffat profile with free beta to the input observations
     """
 
-    def __init__(self, prior=None, fit_pars=None):
-        super().__init__(model="moffat", fit_pars=fit_pars)
+    def __init__(self, obs, guess, prior=None):
+        super().__init__(obs=obs, model='moffat', guess=guess, prior=prior)
 
     def _set_model_class(self):
         import galsim
@@ -549,6 +553,20 @@ class GalsimLMMoffat(GalsimLM):
         else:
             #                 c1  c2  e1e2  r50  beta   fluxes
             self.n_prior_pars = 1 + 1 + 1 + 1 + 1 + self.nband
+
+
+class GalsimLMMOffat(GalsimLM):
+    """
+    Fit the spergel profile to the input observations
+    """
+
+    def __init__(self, prior=None, fit_pars=None):
+        super().__init__(model="moffat", prior=prior, fit_pars=fit_pars)
+
+    def _make_fit_model(self, obs, guess):
+        return GalsimLMMoffatFitModel(
+            obs=obs, guess=guess, prior=self.prior,
+        )
 
 
 class GalsimTemplateFluxFitter(TemplateFluxFitter):

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -32,17 +32,7 @@ class GaussMom(object):
         if res['flags'] != 0:
             logger.debug("        moments failed: %s" % res['flagstr'])
 
-        self._result = res
-
-    def get_result(self):
-        """
-        get the result
-        """
-
-        if not hasattr(self, '_result'):
-            raise RuntimeError("run go() first")
-
-        return self._result
+        return res
 
     def _measure_moments(self, obs):
         """

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -26,6 +26,10 @@ class GaussMom(object):
         obs: Observation, ObsList or MultiBandObsList
             The observations to fit. Note that if an ObsList or a MultiBandObsList
             is passed, the observations are coadded assuming perfect registration.
+
+        Returns
+        -------
+        result dictionary
         """
         res = self._measure_moments(obs=obs)
 

--- a/ngmix/guessers.py
+++ b/ngmix/guessers.py
@@ -232,8 +232,7 @@ def _get_psf_fluxes(rng, obs):
     fitter = TemplateFluxFitter(do_psf=True)
 
     for iband, obslist in enumerate(mbobs):
-        fitter.go(obs=obslist)
-        res = fitter.get_result()
+        res = fitter.go(obs=obslist)
 
         # flags are set for all zero weight pixels, so there isn't anything we
         # can do, we'll have to fix it up

--- a/ngmix/joint_prior.py
+++ b/ngmix/joint_prior.py
@@ -725,6 +725,32 @@ class PriorSpergelSep(PriorSimpleSep):
 
         self.set_bounds()
 
+    def set_bounds(self):
+        """
+        set possibe bounds
+        """
+        bounds = [
+            (None, None),  # c1
+            (None, None),  # c2
+            (None, None),  # g1
+            (None, None),  # g2
+        ]
+
+        allp = [self.r50_prior, self.nu_prior] + self.F_priors
+
+        some_have_bounds = False
+        for i, p in enumerate(allp):
+            if p.has_bounds():
+                some_have_bounds = True
+                bounds.append((p.bounds[0], p.bounds[1]))
+            else:
+                bounds.append((None, None))
+
+        if not some_have_bounds:
+            bounds = None
+
+        self.bounds = bounds
+
     def get_lnprob_scalar(self, pars):
         """
         log probability for scalar input (meaning one point)

--- a/ngmix/metacal/bootstrap.py
+++ b/ngmix/metacal/bootstrap.py
@@ -43,7 +43,7 @@ class MetacalBootstrapper(object):
         obs: ngmix Observation(s)
             Observation, ObsList, or MultiBandObsList
         """
-        self._resdict, self._obsdict = metacal_bootstrap(
+        return metacal_bootstrap(
             obs=obs,
             runner=self.runner,
             psf_runner=self.psf_runner,
@@ -58,38 +58,6 @@ class MetacalBootstrapper(object):
         get a reference to the fitter
         """
         return self.runner.fitter
-
-    def get_result(self):
-        """
-        get the result dict for the last fit
-        """
-        if not hasattr(self, '_resdict'):
-            raise RuntimeError('run go first')
-
-        return self._resdict
-
-    def get_obsdict(self):
-        """
-        get the result dict for the last fit
-        """
-        if not hasattr(self, '_obsdict'):
-            raise RuntimeError('run go first')
-
-        return self._obsdict
-
-    @property
-    def result(self):
-        """
-        get the result dict for the last fit
-        """
-        return self.get_result()
-
-    @property
-    def obsdict(self):
-        """
-        get the metacal observation dict from the last fit
-        """
-        return self.get_obsdict()
 
 
 def metacal_bootstrap(
@@ -142,10 +110,10 @@ def metacal_bootstrap(
     resdict = {}
 
     for key, tobs in obsdict.items():
-        bootstrap(
+        resdict[key] = bootstrap(
             obs=tobs, runner=runner, psf_runner=psf_runner,
             ignore_failed_psf=ignore_failed_psf,
         )
-        resdict[key] = runner.get_result()
+        # resdict[key] = runner.get_result()
 
     return resdict, obsdict

--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -667,11 +667,10 @@ class MetacalFitGaussPSF(MetacalGaussPSF):
         fitter = Admom(rng=self.rng)
 
         run_psf_fitter(obs=psfobs, fitter=fitter, guesser=guesser, ntry=ntry)
-
-        res = fitter.get_result()
+        res = psfobs.meta['result']
 
         if res['flags'] == 0:
-            psf_gmix = fitter.get_gmix()
+            psf_gmix = res.get_gmix()
         else:
             # try maximum likelihood
 
@@ -687,9 +686,10 @@ class MetacalFitGaussPSF(MetacalGaussPSF):
             run_psf_fitter(obs=psfobs, fitter=fitter, guesser=guesser, ntry=ntry)
 
             res = fitter.get_result()
+            res = psfobs.meta['result']
 
             if res['flags'] == 0:
-                psf_gmix = fitter.get_gmix()
+                psf_gmix = res.get_gmix()
             else:
 
                 # see if there was already a gmix that we might use instead

--- a/ngmix/runners.py
+++ b/ngmix/runners.py
@@ -87,13 +87,19 @@ class PSFRunner(RunnerBase):
         ntry: int, optional
             Number of times to try if there is failure
 
+        Returns
+        --------
+        result if obs is an Observation
+        result list if obs is an ObsList
+        list of result lists if obs is a MultiBandObsList
+
         Side Effects
         ------------
         obs.meta['result'] is set to the fit result and the .gmix attribuite is
         set for each successful fit, if appropriate
         """
 
-        run_psf_fitter(
+        return run_psf_fitter(
             obs=obs, fitter=self.fitter, guesser=self.guesser, ntry=self.ntry,
         )
 
@@ -160,16 +166,22 @@ def run_psf_fitter(obs, fitter, guesser=None, ntry=1):
     """
 
     if isinstance(obs, MultiBandObsList):
+        reslol = []
         for tobslist in obs:
-            run_psf_fitter(
+            reslist = run_psf_fitter(
                 obs=tobslist, fitter=fitter, guesser=guesser, ntry=ntry,
             )
+            reslol.append(reslist)
+        return reslol
 
     elif isinstance(obs, ObsList):
+        reslist = []
         for tobs in obs:
-            run_psf_fitter(
+            res = run_psf_fitter(
                 obs=tobs, fitter=fitter, guesser=guesser, ntry=ntry,
             )
+            reslist.append(res)
+        return reslist
 
     elif isinstance(obs, Observation):
 
@@ -188,6 +200,7 @@ def run_psf_fitter(obs, fitter, guesser=None, ntry=1):
             gmix = res.get_gmix()
             obs_to_fit.gmix = gmix
 
+        return res
     else:
         raise ValueError(
             'obs must be an Observation, ObsList, or MultiBandObsList'

--- a/ngmix/runners.py
+++ b/ngmix/runners.py
@@ -54,15 +54,9 @@ class Runner(RunnerBase):
         result dictionary
         """
 
-        run_fitter(
+        return run_fitter(
             obs=obs, fitter=self.fitter, guesser=self.guesser, ntry=self.ntry,
         )
-
-    def get_result(self):
-        """
-        get the result dict
-        """
-        return self.fitter.get_result()
 
 
 class PSFRunner(RunnerBase):
@@ -130,13 +124,14 @@ def run_fitter(obs, fitter, guesser=None, ntry=1):
 
         if guesser is not None:
             guess = guesser(obs=obs)
-            fitter.go(obs=obs, guess=guess)
+            res = fitter.go(obs=obs, guess=guess)
         else:
-            fitter.go(obs=obs)
+            res = fitter.go(obs=obs)
 
-        res = fitter.get_result()
         if res['flags'] == 0:
             break
+
+    return res
 
 
 def run_psf_fitter(obs, fitter, guesser=None, ntry=1):
@@ -183,15 +178,14 @@ def run_psf_fitter(obs, fitter, guesser=None, ntry=1):
         else:
             obs_to_fit = obs
 
-        run_fitter(
+        res = run_fitter(
             obs=obs_to_fit, fitter=fitter, guesser=guesser, ntry=ntry,
         )
 
-        res = fitter.get_result()
         obs_to_fit.meta['result'] = res
 
-        if res['flags'] == 0 and hasattr(fitter, 'get_gmix'):
-            gmix = fitter.get_gmix()
+        if res['flags'] == 0 and hasattr(res, 'get_gmix'):
+            gmix = res.get_gmix()
             obs_to_fit.gmix = gmix
 
     else:

--- a/ngmix/tests/_priors.py
+++ b/ngmix/tests/_priors.py
@@ -52,7 +52,7 @@ def get_prior(*, fit_model, rng, scale, T_range=None, F_range=None, nband=None):
     return prior
 
 
-def get_prior_galsimfit(*, rng, scale, r50_range=None, F_range=None):
+def get_prior_galsimfit(*, model, rng, scale, r50_range=None, F_range=None):
 
     if r50_range is None:
         r50_range = [0.01, 10]
@@ -70,11 +70,25 @@ def get_prior_galsimfit(*, rng, scale, r50_range=None, F_range=None):
         minval=F_range[0], maxval=F_range[1], rng=rng,
     )
 
-    prior = ngmix.joint_prior.PriorGalsimSimpleSep(
-        cen_prior=cen_prior,
-        g_prior=g_prior,
-        r50_prior=r50_prior,
-        F_prior=F_prior,
-    )
+    if model == 'spergel':
+        nu_prior = ngmix.priors.FlatPrior(
+            minval=-.5, maxval=3, rng=rng,
+        )
+        prior = ngmix.joint_prior.PriorSpergelSep(
+            cen_prior=cen_prior,
+            g_prior=g_prior,
+            r50_prior=r50_prior,
+            nu_prior=nu_prior,
+            F_prior=F_prior,
+        )
+
+    else:
+
+        prior = ngmix.joint_prior.PriorGalsimSimpleSep(
+            cen_prior=cen_prior,
+            g_prior=g_prior,
+            r50_prior=r50_prior,
+            F_prior=F_prior,
+        )
 
     return prior

--- a/ngmix/tests/test_admom.py
+++ b/ngmix/tests/test_admom.py
@@ -66,10 +66,9 @@ def test_admom_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
             jacobian=jac)
         try:
             Tguess = fwhm_to_T(fwhm) + rng.normal()*0.01
-            fitter.go(obs=obs, guess=Tguess)
-            res = fitter.get_result()
+            res = fitter.go(obs=obs, guess=Tguess)
             if res['flags'] == 0:
-                gm = fitter.get_gmix()
+                gm = res.get_gmix()
                 _g1, _g2, _T = gm.get_g1g2T()
 
                 g1arr.append(_g1)

--- a/ngmix/tests/test_bootstrap.py
+++ b/ngmix/tests/test_bootstrap.py
@@ -85,12 +85,10 @@ def test_bootstrap(model, psf_model_type, guess_from_moms, noise,
 
     if use_bootstrapper:
         boot = Bootstrapper(runner=runner, psf_runner=psf_runner)
-        boot.go(obs)
+        res = boot.go(obs)
     else:
-        bootstrap(obs=obs, runner=runner, psf_runner=psf_runner)
+        res = bootstrap(obs=obs, runner=runner, psf_runner=psf_runner)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
     assert res['flags'] == 0
 
     pixel_scale = obs.jacobian.scale
@@ -108,7 +106,7 @@ def test_bootstrap(model, psf_model_type, guess_from_moms, noise,
         assert abs(res['pars'][5]/data['pars'][5] - 1) < FRAC_TOL
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
     maxdiff = np.abs(imfit - obs.image).max()
     immax = obs.image.max()
     # imtol = 0.001 / pixel_scale**2 + noise*5

--- a/ngmix/tests/test_em.py
+++ b/ngmix/tests/test_em.py
@@ -42,11 +42,11 @@ def test_em_1gauss(noise):
     gm_guess = gm.copy()
     randomize_gmix(rng=rng, gmix=gm_guess, pixel_scale=pixel_scale)
 
-    fitter = fit_em(obs=obs, guess=gm_guess)
+    res = fit_em(obs=obs, guess=gm_guess)
 
-    fit_gm = fitter.get_gmix()
-    res = fitter.get_result()
     assert res['flags'] == 0
+
+    fit_gm = res.get_gmix()
 
     fitpars = fit_gm.get_full_pars()
 
@@ -59,7 +59,7 @@ def test_em_1gauss(noise):
         assert abs(fitpars[5]/pars[5]-1) < FRAC_TOL
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
     imtol = 0.001 / pixel_scale**2 + noise*5
     assert np.all(np.abs(imfit - obs.image) < imtol)
 
@@ -87,12 +87,10 @@ def test_em_2gauss(noise):
     gm_guess = gm.copy()
     randomize_gmix(rng=rng, gmix=gm_guess, pixel_scale=pixel_scale)
 
-    fitter = fit_em(obs=obs, guess=gm_guess)
-
-    fit_gm = fitter.get_gmix()
-
-    res = fitter.get_result()
+    res = fit_em(obs=obs, guess=gm_guess)
     assert res['flags'] == 0
+
+    fit_gm = res.get_gmix()
 
     fitpars = fit_gm.get_full_pars()
 
@@ -123,7 +121,7 @@ def test_em_2gauss(noise):
             assert abs(thispars[5]/truepars[5]-1) < FRAC_TOL
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
     imtol = 0.001 / pixel_scale**2 + noise*5
     assert np.all(np.abs(imfit - obs.image) < imtol)
 
@@ -157,11 +155,10 @@ def test_em_2gauss_withpsf(noise):
     gm_guess = gm.copy()
     randomize_gmix(rng=rng, gmix=gm_guess, pixel_scale=pixel_scale)
 
-    fitter = fit_em(obs=obs, guess=gm_guess, tol=1.0e-5)
-
-    fit_gm = fitter.get_gmix()
-    res = fitter.get_result()
+    res = fit_em(obs=obs, guess=gm_guess, tol=1.0e-5)
     assert res['flags'] == 0
+
+    fit_gm = res.get_gmix()
 
     fitpars = fit_gm.get_full_pars()
 
@@ -193,6 +190,6 @@ def test_em_2gauss_withpsf(noise):
             assert abs(thispars[5]/truepars[5]-1) < FRAC_TOL
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
     imtol = 0.001 / pixel_scale**2 + noise*5
     assert np.all(np.abs(imfit - obs.image) < imtol)

--- a/ngmix/tests/test_gaussmom.py
+++ b/ngmix/tests/test_gaussmom.py
@@ -70,8 +70,7 @@ def test_gaussmom_smoke(g1_true, g2_true, wcs_g1, wcs_g2, weight_fac):
             jacobian=jac)
         # use a huge weight so that we get the raw moments back out
         try:
-            fitter.go(obs=obs)
-            res = fitter.get_result()
+            res = fitter.go(obs=obs)
             if res['flags'] == 0:
                 if weight_fac > 1:
                     # for unweighted we need to convert e to g

--- a/ngmix/tests/test_metacal_bootstrap.py
+++ b/ngmix/tests/test_metacal_bootstrap.py
@@ -74,9 +74,7 @@ def test_metacal_bootstrap_max_smoke(noise, use_bootstrapper, nband, nepoch):
             runner=runner, psf_runner=psf_runner,
             rng=rng,
         )
-        boot.go(obs)
-        resdict = boot.result
-        obsdict = boot.obsdict
+        resdict, obsdict = boot.go(obs)
     else:
         resdict, obsdict = metacal_bootstrap(
             obs=obs, runner=runner, psf_runner=psf_runner,
@@ -121,9 +119,7 @@ def test_metacal_bootstrap_gaussmom_smoke(noise, use_bootstrapper):
             runner=runner, psf_runner=psf_runner,
             rng=rng,
         )
-        boot.go(obs)
-        resdict = boot.result
-        obsdict = boot.obsdict
+        resdict, obsdict = boot.go(obs)
     else:
         resdict, obsdict = metacal_bootstrap(
             obs=obs, runner=runner, psf_runner=psf_runner,
@@ -168,8 +164,7 @@ def test_metacal_bootstrap_gaussmom_response():
             set_noise_image=False,
         )
 
-        boot.go(obs)
-        resdict = boot.get_result()
+        resdict, obsdict = boot.go(obs)
 
         res1p = resdict['1p']
         res1m = resdict['1m']

--- a/ngmix/tests/test_ml_fitting_exp_obj_gauss_psf.py
+++ b/ngmix/tests/test_ml_fitting_exp_obj_gauss_psf.py
@@ -103,8 +103,9 @@ def test_ml_fitting_exp_obj_gauss_psf_smoke(
             jacobian=jac,
             psf=psf_obs)
 
-        fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
-        res = fitter.get_result()
+        res = fitter.go(
+            obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01,
+        )
         if res['flags'] == 0:
             _g1, _g2, _ = res['g'][0], res['g'][1], res['pars'][4]
             g1arr.append(_g1)

--- a/ngmix/tests/test_ml_fitting_galsim.py
+++ b/ngmix/tests/test_ml_fitting_galsim.py
@@ -2,9 +2,7 @@ import galsim
 import numpy as np
 import pytest
 
-from ngmix.galsimfit import GalsimLM
-from ngmix import Jacobian
-from ngmix import Observation
+import ngmix
 from ._priors import get_prior_galsimfit
 
 
@@ -15,7 +13,7 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
 
     rng = np.random.RandomState(seed=2312)
     scale = 0.263
-    prior = get_prior_galsimfit(rng=rng, scale=scale)
+    prior = get_prior_galsimfit(model=model, rng=rng, scale=scale)
 
     psf_fwhm = 0.9
     psf_image_size = 33
@@ -37,13 +35,13 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
     ).array
 
     psf_cen = (psf_image_size - 1.0)/2.0
-    psf_jac = Jacobian(
+    psf_jac = ngmix.Jacobian(
         y=psf_cen, x=psf_cen,
         dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
         dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
     )
 
-    psf_obs = Observation(
+    psf_obs = ngmix.Observation(
         image=psf_im,
         jacobian=psf_jac,
     )
@@ -55,7 +53,7 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
     xarr = []
     yarr = []
 
-    fitter = GalsimLM(model='exp', prior=prior)
+    fitter = ngmix.galsimfit.GalsimLM(model='exp', prior=prior)
 
     for _ in range(50):
         shift = rng.uniform(low=-scale/2, high=scale/2, size=2)
@@ -83,14 +81,14 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
         wgt = np.ones_like(im) / noise**2
 
         cen = (np.array(im.shape)-1)/2
-        jac = Jacobian(
+        jac = ngmix.Jacobian(
             y=cen[0] + xy.y, x=cen[1] + xy.x,
             dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
             dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
         )
 
         _im = im + (rng.normal(size=im.shape) * noise)
-        obs = Observation(
+        obs = ngmix.Observation(
             image=_im,
             weight=wgt,
             jacobian=jac,
@@ -104,8 +102,7 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
         guess[4] = hlr * rng.uniform(low=0.9, high=1.1)
         guess[5] = flux * rng.uniform(low=0.9, high=1.1)
 
-        fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
-        res = fitter.get_result()
+        res = fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
         if res['flags'] == 0:
             _g1, _g2, _ = res['g'][0], res['g'][1], res['pars'][4]
             g1arr.append(_g1 - g1_true)
@@ -133,3 +130,98 @@ def test_ml_fitting_galsim(wcs_g1, wcs_g2, model):
     assert np.abs(np.mean(xarr)) < xerr * 5
     yerr = np.std(yarr) / np.sqrt(len(yarr))
     assert np.abs(np.mean(yarr)) < yerr * 5
+
+
+def test_ml_fitting_galsim_spergel_smoke():
+
+    rng = np.random.RandomState(seed=2312)
+    scale = 0.263
+    prior = get_prior_galsimfit(model='spergel', rng=rng, scale=scale)
+
+    psf_fwhm = 0.9
+    psf_image_size = 33
+    image_size = 51
+
+    noise = 0.001
+
+    hlr = 0.1
+    flux = 400
+
+    gs_wcs = galsim.ShearWCS(
+        scale,
+        galsim.Shear(g1=0.01, g2=-0.01),
+    ).jacobian()
+
+
+    psf_im = galsim.Gaussian(fwhm=psf_fwhm).drawImage(
+        nx=psf_image_size,
+        ny=psf_image_size,
+        wcs=gs_wcs,
+    ).array
+
+    psf_cen = (psf_image_size - 1.0)/2.0
+    psf_jac = ngmix.Jacobian(
+        y=psf_cen, x=psf_cen,
+        dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
+        dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
+    )
+
+    psf_obs = ngmix.Observation(
+        image=psf_im,
+        jacobian=psf_jac,
+    )
+
+    guess = prior.sample()
+
+    fitter = ngmix.galsimfit.GalsimLMSpergel(prior=prior)
+
+    for _ in range(50):
+        shift = rng.uniform(low=-scale/2, high=scale/2, size=2)
+        xy = gs_wcs.toImage(galsim.PositionD(shift))
+
+        g1_true, g2_true = prior.g_prior.sample2d()
+        gal = galsim.Exponential(
+            half_light_radius=hlr,
+        ).shear(
+            g1=g1_true, g2=g2_true
+        ).withFlux(
+            flux,
+        )
+
+        obj = galsim.Convolve([gal, galsim.Gaussian(fwhm=psf_fwhm)])
+
+        im = obj.shift(
+            dx=shift[0], dy=shift[1]
+        ).drawImage(
+            nx=image_size,
+            ny=image_size,
+            wcs=gs_wcs,
+            dtype=np.float64,
+        ).array
+        wgt = np.ones_like(im) / noise**2
+
+        cen = (np.array(im.shape)-1)/2
+        jac = ngmix.Jacobian(
+            y=cen[0] + xy.y, x=cen[1] + xy.x,
+            dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
+            dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
+        )
+
+        _im = im + (rng.normal(size=im.shape) * noise)
+        obs = ngmix.Observation(
+            image=_im,
+            weight=wgt,
+            jacobian=jac,
+            psf=psf_obs,
+        )
+
+        guess[0] = rng.uniform(low=-0.1, high=0.1)
+        guess[1] = rng.uniform(low=-0.1, high=0.1)
+        guess[2] = rng.uniform(low=-0.1, high=0.1)
+        guess[3] = rng.uniform(low=-0.1, high=0.1)
+        guess[4] = hlr * rng.uniform(low=0.9, high=1.1)
+        guess[5] = rng.uniform(low=0, high=2)
+        guess[6] = flux * rng.uniform(low=0.9, high=1.1)
+
+        res = fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
+        assert res['flags'] == 0

--- a/ngmix/tests/test_ml_fitting_galsim.py
+++ b/ngmix/tests/test_ml_fitting_galsim.py
@@ -152,7 +152,6 @@ def test_ml_fitting_galsim_spergel_smoke():
         galsim.Shear(g1=0.01, g2=-0.01),
     ).jacobian()
 
-
     psf_im = galsim.Gaussian(fwhm=psf_fwhm).drawImage(
         nx=psf_image_size,
         ny=psf_image_size,
@@ -175,53 +174,101 @@ def test_ml_fitting_galsim_spergel_smoke():
 
     fitter = ngmix.galsimfit.GalsimLMSpergel(prior=prior)
 
-    for _ in range(50):
-        shift = rng.uniform(low=-scale/2, high=scale/2, size=2)
-        xy = gs_wcs.toImage(galsim.PositionD(shift))
+    shift = rng.uniform(low=-scale/2, high=scale/2, size=2)
+    xy = gs_wcs.toImage(galsim.PositionD(shift))
 
-        g1_true, g2_true = prior.g_prior.sample2d()
-        gal = galsim.Exponential(
-            half_light_radius=hlr,
-        ).shear(
-            g1=g1_true, g2=g2_true
-        ).withFlux(
-            flux,
-        )
+    g1_true, g2_true = prior.g_prior.sample2d()
+    gal = galsim.Exponential(
+        half_light_radius=hlr,
+    ).shear(
+        g1=g1_true, g2=g2_true
+    ).withFlux(
+        flux,
+    )
 
-        obj = galsim.Convolve([gal, galsim.Gaussian(fwhm=psf_fwhm)])
+    obj = galsim.Convolve([gal, galsim.Gaussian(fwhm=psf_fwhm)])
 
-        im = obj.shift(
-            dx=shift[0], dy=shift[1]
-        ).drawImage(
-            nx=image_size,
-            ny=image_size,
-            wcs=gs_wcs,
-            dtype=np.float64,
-        ).array
-        wgt = np.ones_like(im) / noise**2
+    im = obj.shift(
+        dx=shift[0], dy=shift[1]
+    ).drawImage(
+        nx=image_size,
+        ny=image_size,
+        wcs=gs_wcs,
+        dtype=np.float64,
+    ).array
+    wgt = np.ones_like(im) / noise**2
 
-        cen = (np.array(im.shape)-1)/2
-        jac = ngmix.Jacobian(
-            y=cen[0] + xy.y, x=cen[1] + xy.x,
-            dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
-            dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
-        )
+    cen = (np.array(im.shape)-1)/2
+    jac = ngmix.Jacobian(
+        y=cen[0] + xy.y, x=cen[1] + xy.x,
+        dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
+        dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy,
+    )
 
-        _im = im + (rng.normal(size=im.shape) * noise)
-        obs = ngmix.Observation(
-            image=_im,
-            weight=wgt,
-            jacobian=jac,
-            psf=psf_obs,
-        )
+    _im = im + (rng.normal(size=im.shape) * noise)
+    obs = ngmix.Observation(
+        image=_im,
+        weight=wgt,
+        jacobian=jac,
+        psf=psf_obs,
+    )
 
-        guess[0] = rng.uniform(low=-0.1, high=0.1)
-        guess[1] = rng.uniform(low=-0.1, high=0.1)
-        guess[2] = rng.uniform(low=-0.1, high=0.1)
-        guess[3] = rng.uniform(low=-0.1, high=0.1)
-        guess[4] = hlr * rng.uniform(low=0.9, high=1.1)
-        guess[5] = rng.uniform(low=0, high=2)
-        guess[6] = flux * rng.uniform(low=0.9, high=1.1)
+    guess[0] = rng.uniform(low=-0.1, high=0.1)
+    guess[1] = rng.uniform(low=-0.1, high=0.1)
+    guess[2] = rng.uniform(low=-0.1, high=0.1)
+    guess[3] = rng.uniform(low=-0.1, high=0.1)
+    guess[4] = hlr * rng.uniform(low=0.9, high=1.1)
+    guess[5] = rng.uniform(low=0, high=2)
+    guess[6] = flux * rng.uniform(low=0.9, high=1.1)
 
-        res = fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
-        assert res['flags'] == 0
+    res = fitter.go(obs=obs, guess=guess + rng.normal(size=guess.size) * 0.01)
+    assert res['flags'] == 0
+
+
+def test_ml_fitting_galsim_moffat_smoke():
+
+    rng = np.random.RandomState(seed=2312)
+
+    scale = 0.263
+    fwhm = 0.9
+    beta = 2.5
+    image_size = 33
+    flux = 1.0
+
+    noise = 1.0e-5
+
+    moff = galsim.Moffat(fwhm=fwhm, beta=beta, flux=flux)
+    im = moff.drawImage(
+        nx=image_size,
+        ny=image_size,
+        scale=scale,
+    ).array
+    im += rng.normal(scale=noise, size=im.shape)
+    weight = im*0 + 1.0/noise**2
+
+    cen = (image_size - 1.0)/2.0
+    jac = ngmix.DiagonalJacobian(
+        y=cen, x=cen,
+        scale=scale,
+    )
+
+    obs = ngmix.Observation(
+        image=im,
+        weight=weight,
+        jacobian=jac,
+    )
+
+    fitter = ngmix.galsimfit.GalsimLMMOffat()
+
+    guess = np.zeros(7)
+
+    guess[0] = rng.uniform(low=-0.1, high=0.1)
+    guess[1] = rng.uniform(low=-0.1, high=0.1)
+    guess[2] = rng.uniform(low=-0.1, high=0.1)
+    guess[3] = rng.uniform(low=-0.1, high=0.1)
+    guess[4] = moff.half_light_radius * rng.uniform(low=0.9, high=1.1)
+    guess[5] = rng.uniform(low=1.5, high=3)
+    guess[6] = flux * rng.uniform(low=0.9, high=1.1)
+
+    res = fitter.go(obs=obs, guess=guess)
+    assert res['flags'] == 0

--- a/ngmix/tests/test_ml_fitting_gauss.py
+++ b/ngmix/tests/test_ml_fitting_gauss.py
@@ -98,9 +98,7 @@ def test_ml_max_fitting_gauss_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
         guess[4] = fwhm_to_T(0.9) * rng.uniform(low=0.99, high=1.01)
         guess[5] = flux * scale**2 * rng.uniform(low=0.99, high=1.01)
 
-        # guess = guess + rng.normal(size=6) * 0.01
         res = fitter.go(obs=obs, guess=guess)
-        # res = fitter.get_result()
 
         if res['flags'] == 0:
             _g1, _g2, _T = res['g'][0], res['g'][1], res['pars'][4]

--- a/ngmix/tests/test_ml_fitting_gauss.py
+++ b/ngmix/tests/test_ml_fitting_gauss.py
@@ -99,8 +99,8 @@ def test_ml_max_fitting_gauss_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
         guess[5] = flux * scale**2 * rng.uniform(low=0.99, high=1.01)
 
         # guess = guess + rng.normal(size=6) * 0.01
-        fitter.go(obs=obs, guess=guess)
-        res = fitter.get_result()
+        res = fitter.go(obs=obs, guess=guess)
+        # res = fitter.get_result()
 
         if res['flags'] == 0:
             _g1, _g2, _T = res['g'][0], res['g'][1], res['pars'][4]

--- a/ngmix/tests/test_psf_runners.py
+++ b/ngmix/tests/test_psf_runners.py
@@ -35,9 +35,7 @@ def test_em_psf_runner_smoke(ngauss, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=obs)
-
-    res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -79,12 +77,7 @@ def test_em_psf_runner(with_psf_obs, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=obs)
-
-    if with_psf_obs:
-        res = obs.psf.meta['result']
-    else:
-        res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -124,9 +117,7 @@ def test_simple_psf_runner_smoke(model, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=data['obs'])
-
-    res = data['obs'].meta['result']
+    res = runner.go(obs=data['obs'])
 
     assert res['flags'] == 0
 
@@ -155,9 +146,7 @@ def test_simple_psf_runner(model, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=data['obs'])
-
-    res = data['obs'].meta['result']
+    res = runner.go(obs=data['obs'])
 
     assert res['flags'] == 0
 
@@ -203,8 +192,7 @@ def test_coellip_psf_runner_smoke(ngauss, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=obs)
-    res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -244,12 +232,7 @@ def test_coellip_psf_runner(with_psf_obs, guess_from_moms):
         guesser=guesser,
         ntry=4,
     )
-    runner.go(obs=obs)
-
-    if with_psf_obs:
-        res = obs.psf.meta['result']
-    else:
-        res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -290,9 +273,7 @@ def test_admom_psf_runner_smoke(ngauss, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=obs)
-
-    res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -334,12 +315,7 @@ def test_admom_psf_runner(with_psf_obs, guess_from_moms):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=obs)
-
-    if with_psf_obs:
-        res = obs.psf.meta['result']
-    else:
-        res = obs.meta['result']
+    res = runner.go(obs=obs)
 
     assert res['flags'] == 0
 
@@ -377,14 +353,19 @@ def test_gaussmom_psf_runner(nband, nepoch):
     fitter = ngmix.gaussmom.GaussMom(fwhm=1.2)
 
     runner = PSFRunner(fitter=fitter)
-    runner.go(obs=obs)
+    res = runner.go(obs=obs)
 
     if nband is not None:
+        assert isinstance(res, list)
+        assert isinstance(res[0], list)
+
         for tobslist in obs:
             for tobs in tobslist:
                 assert 'result' in tobs.psf.meta
     elif nepoch is not None:
+        assert isinstance(res, list)
         for tobs in obs:
             assert 'result' in tobs.psf.meta
     else:
+        assert hasattr(res, 'keys')
         assert 'result' in obs.psf.meta

--- a/ngmix/tests/test_psf_runners.py
+++ b/ngmix/tests/test_psf_runners.py
@@ -37,8 +37,8 @@ def test_em_psf_runner_smoke(ngauss, guess_from_moms):
     )
     runner.go(obs=obs)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    res = obs.meta['result']
+
     assert res['flags'] == 0
 
 
@@ -81,12 +81,15 @@ def test_em_psf_runner(with_psf_obs, guess_from_moms):
     )
     runner.go(obs=obs)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    if with_psf_obs:
+        res = obs.psf.meta['result']
+    else:
+        res = obs.meta['result']
+
     assert res['flags'] == 0
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
 
     if with_psf_obs:
         comp_image = obs.psf.image
@@ -123,8 +126,8 @@ def test_simple_psf_runner_smoke(model, guess_from_moms):
     )
     runner.go(obs=data['obs'])
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    res = data['obs'].meta['result']
+
     assert res['flags'] == 0
 
 
@@ -154,12 +157,12 @@ def test_simple_psf_runner(model, guess_from_moms):
     )
     runner.go(obs=data['obs'])
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    res = data['obs'].meta['result']
+
     assert res['flags'] == 0
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
 
     obs = data['obs']
 
@@ -201,9 +204,8 @@ def test_coellip_psf_runner_smoke(ngauss, guess_from_moms):
         ntry=2,
     )
     runner.go(obs=obs)
+    res = obs.meta['result']
 
-    fitter = runner.fitter
-    res = fitter.get_result()
     assert res['flags'] == 0
 
 
@@ -244,12 +246,15 @@ def test_coellip_psf_runner(with_psf_obs, guess_from_moms):
     )
     runner.go(obs=obs)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    if with_psf_obs:
+        res = obs.psf.meta['result']
+    else:
+        res = obs.meta['result']
+
     assert res['flags'] == 0
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
 
     if with_psf_obs:
         comp_image = obs.psf.image
@@ -287,8 +292,8 @@ def test_admom_psf_runner_smoke(ngauss, guess_from_moms):
     )
     runner.go(obs=obs)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    res = obs.meta['result']
+
     assert res['flags'] == 0
 
 
@@ -331,12 +336,15 @@ def test_admom_psf_runner(with_psf_obs, guess_from_moms):
     )
     runner.go(obs=obs)
 
-    fitter = runner.fitter
-    res = fitter.get_result()
+    if with_psf_obs:
+        res = obs.psf.meta['result']
+    else:
+        res = obs.meta['result']
+
     assert res['flags'] == 0
 
     # check reconstructed image allowing for noise
-    imfit = fitter.make_image()
+    imfit = res.make_image()
 
     if with_psf_obs:
         comp_image = obs.psf.image

--- a/ngmix/tests/test_psf_runners.py
+++ b/ngmix/tests/test_psf_runners.py
@@ -333,7 +333,8 @@ def test_admom_psf_runner(with_psf_obs, guess_from_moms):
 
 @pytest.mark.parametrize('nband', [None, 3])
 @pytest.mark.parametrize('nepoch', [None, 1, 3])
-def test_gaussmom_psf_runner(nband, nepoch):
+@pytest.mark.parametrize('set_result', [True, False])
+def test_gaussmom_psf_runner(nband, nepoch, set_result):
     """
     Test a PSFRunner using GaussMom
     """
@@ -352,7 +353,7 @@ def test_gaussmom_psf_runner(nband, nepoch):
 
     fitter = ngmix.gaussmom.GaussMom(fwhm=1.2)
 
-    runner = PSFRunner(fitter=fitter)
+    runner = PSFRunner(fitter=fitter, set_result=set_result)
     res = runner.go(obs=obs)
 
     if nband is not None:
@@ -361,11 +362,20 @@ def test_gaussmom_psf_runner(nband, nepoch):
 
         for tobslist in obs:
             for tobs in tobslist:
-                assert 'result' in tobs.psf.meta
+                if set_result:
+                    assert 'result' in tobs.psf.meta
+                else:
+                    assert 'result' not in tobs.psf.meta
     elif nepoch is not None:
         assert isinstance(res, list)
         for tobs in obs:
-            assert 'result' in tobs.psf.meta
+            if set_result:
+                assert 'result' in tobs.psf.meta
+            else:
+                assert 'result' not in tobs.psf.meta
     else:
         assert hasattr(res, 'keys')
-        assert 'result' in obs.psf.meta
+        if set_result:
+            assert 'result' in obs.psf.meta
+        else:
+            assert 'result' not in obs.psf.meta

--- a/ngmix/tests/test_runners.py
+++ b/ngmix/tests/test_runners.py
@@ -158,7 +158,6 @@ def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
             res_old = res
 
 
-'''
 def test_gaussmom_runner():
     """
     Test a Runner using GaussMom
@@ -180,4 +179,3 @@ def test_gaussmom_runner():
     res = runner.go(obs=obs)
     assert res['flags'] == 0
     assert res['pars'].size == 6
-'''

--- a/ngmix/tests/test_runners.py
+++ b/ngmix/tests/test_runners.py
@@ -63,14 +63,12 @@ def test_runner_lm_simple_smoke(model, psf_model_type):
         guesser=guesser,
         ntry=2,
     )
-    runner.go(obs=data['obs'])
-
-    res = runner.get_result()
+    res = runner.go(obs=data['obs'])
     assert res['flags'] == 0
 
 
 @pytest.mark.parametrize('guesser_type', ['TF', 'TPSFFlux'])
-@pytest.mark.parametrize('psf_model_type', ['em', 'coellip'])
+@pytest.mark.parametrize('psf_model_type', ['coellip', 'em'])
 @pytest.mark.parametrize('model', ['exp', 'dev'])
 @pytest.mark.parametrize('noise', [1.0e-8, 0.01])
 def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
@@ -111,6 +109,7 @@ def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
             ntry=2,
         )
         psf_runner.go(obs=obs)
+        assert obs.psf.has_gmix()
 
         if guesser_type == 'TF':
             guesser = TFluxGuesser(
@@ -133,10 +132,8 @@ def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
             guesser=guesser,
             ntry=2,
         )
-        runner.go(obs=obs)
+        res = runner.go(obs=obs)
 
-        fitter = runner.fitter
-        res = fitter.get_result()
         assert res['flags'] == 0
 
         pixel_scale = obs.jacobian.scale
@@ -151,7 +148,7 @@ def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
             assert abs(res['pars'][5]/data['pars'][5] - 1) < FRAC_TOL
 
         # check reconstructed image allowing for noise
-        imfit = fitter.make_image()
+        imfit = res.make_image()
         imtol = 0.001 / pixel_scale**2 + noise*5
         assert np.all(np.abs(imfit - obs.image) < imtol)
 
@@ -161,6 +158,7 @@ def test_runner_lm_simple(model, psf_model_type, noise, guesser_type):
             res_old = res
 
 
+'''
 def test_gaussmom_runner():
     """
     Test a Runner using GaussMom
@@ -179,8 +177,7 @@ def test_gaussmom_runner():
     fitter = ngmix.gaussmom.GaussMom(fwhm=1.2)
 
     runner = Runner(fitter=fitter)
-    runner.go(obs=obs)
-
-    res = runner.get_result()
+    res = runner.go(obs=obs)
     assert res['flags'] == 0
     assert res['pars'].size == 6
+'''

--- a/ngmix/tests/test_template_flux.py
+++ b/ngmix/tests/test_template_flux.py
@@ -25,14 +25,12 @@ def test_template_psf_flux(noise, nband):
     fitter = TemplateFluxFitter(do_psf=True)
 
     if nband is None:
-        fitter.go(obs=data['obs'])
-        res = fitter.get_result()
+        res = fitter.go(obs=data['obs'])
         assert res['flags'] == 0
         assert (res['flux'] - data['pars'][5]) < NSIG*res['flux_err']
     else:
         for iband, obslist in enumerate(data['obs']):
-            fitter.go(obs=obslist)
-            res = fitter.get_result()
+            res = fitter.go(obs=obslist)
             assert res['flags'] == 0
             assert (res['flux'] - data['pars'][5+iband]) < NSIG*res['flux_err']
 
@@ -54,15 +52,13 @@ def test_template_psf_flux_galsim(noise, nband):
     fitter = GalsimTemplateFluxFitter()
 
     if nband is None:
-        fitter.go(obs=data['obs'])
+        res = fitter.go(obs=data['obs'])
         scale = data['obs'][0].jacobian.scale
-        res = fitter.get_result()
         assert res['flags'] == 0
         assert (res['flux']*scale**2 - data['pars'][5]) < NSIG*res['flux_err']
     else:
         for iband, obslist in enumerate(data['obs']):
-            fitter.go(obs=obslist)
+            res = fitter.go(obs=obslist)
             scale = data['obs'][0][0].jacobian.scale
-            res = fitter.get_result()
             assert res['flags'] == 0
             assert (res['flux']**scale - data['pars'][5+iband]) < NSIG*res['flux_err']


### PR DESCRIPTION
This was suggested by @beckermr 

TODO

- [x] make the psf runners/bootstrappers return results/lists of results.  Only set result if requested (old behavior)
- [x] docs
- [x] update examples
- [x] port over metadetect tests