### PR TITLE
ENH allow store pixels and ignore zero weight to be set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 - fixed a bug in `ngmix.priors.TwoSidedErf.get_fdiff` in handling array inputs
 - fixed bug in `TruncatedSimpleGauss2D` where the truncation radius was applied about
   zero in some methods and not about the center
+- fixed flux unit scaling in metadetect regression tests
 
 ### new features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
     - GalsimTemplateFluxFitter -> GalsimPSFFluxFitter
     - GMixEM -> EMFitter
     - Admom -> AdmomFitter
+- Copies of observations now propagate the values of `store_pixels` and `ignore_zero_weight`.
 
 ### bug fixes
 
@@ -75,6 +76,9 @@
     - GMixEMFluxOnly: fit mixtures allowing only the fluxes to vary
 - some refactoring of like modules into sub-packages.
 - Added `mfrac` attribute to observations to hold masked fraction images.
+- Added Python `@property` functions for `store_pixels` and `ignore_zero_weight`
+  for `ngmix.Observation`.
+- `setup.py` now gets the version from the package.
 
 ### deprecated/removed
 

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -245,7 +245,11 @@ def test_mdet_regression(fname, write=False):
                     adata = all_res[col]
                     odata = old_data[col].copy()
                     odata[5] = odata[5] * SCALE**2
-                elif col.startswith('wmom_band_flux') and '1.3.8' in fname:
+                elif (
+                    col.startswith('wmom_band_flux')
+                    and not col.endswith('flags')
+                    and '1.3.8' in fname
+                ):
                     odata = old_data[col].copy() * SCALE**2
                 else:
                     adata = all_res[col]

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -242,8 +242,9 @@ def test_mdet_regression(fname, write=False):
             if np.issubdtype(old_data[col].dtype, np.number):
 
                 if col == 'wmom_pars' and '1.3.8' in fname:
-                    adata = all_res[col][:, :5]
-                    odata = old_data[col][:, :5]
+                    adata = all_res[col]
+                    odata = old_data[col].copy()
+                    odata[5] = odata[5] * SCALE**2
                 elif col.startswith('wmom_band_flux') and '1.3.8' in fname:
                     odata = old_data[col].copy() * SCALE**2
                 else:

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -106,9 +106,11 @@ TEST_METADETECT_CONFIG = {
     'imperfect_flags': 0,
 }
 
+SCALE = 0.25
+
 
 def make_sim(seed=42):
-    scale = 0.25
+    scale = SCALE
     flux = 10.0**(0.4 * (30 - 18))
     noise = 10
     ngals = 120
@@ -242,6 +244,8 @@ def test_mdet_regression(fname, write=False):
                 if col == 'wmom_pars' and '1.3.8' in fname:
                     adata = all_res[col][:, :5]
                     odata = old_data[col][:, :5]
+                elif col.startswith('wmom_band_flux') and '1.3.8' in fname:
+                    odata = old_data[col].copy() * SCALE**2
                 else:
                     adata = all_res[col]
                     odata = old_data[col]

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -250,6 +250,7 @@ def test_mdet_regression(fname, write=False):
                     and not col.endswith('flags')
                     and '1.3.8' in fname
                 ):
+                    adata = all_res[col]
                     odata = old_data[col].copy() * SCALE**2
                 else:
                     adata = all_res[col]

--- a/ngmix/__init__.py
+++ b/ngmix/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = '2.0.0rc1'
+from ._version import __version__
 
 from . import util
 from .util import print_pars

--- a/ngmix/_version.py
+++ b/ngmix/_version.py
@@ -1,0 +1,1 @@
+__version__ = '2.0.0rc1'  # noqa

--- a/ngmix/observation.py
+++ b/ngmix/observation.py
@@ -722,7 +722,42 @@ class Observation(MetadataMixin):
             meta=meta,
             psf=psf,
             mfrac=mfrac,
+            store_pixels=self._store_pixels,
+            ignore_zero_weight=self._ignore_zero_weight,
         )
+
+    @property
+    def store_pixels(self):
+        """getter for store_pixels attribute"""
+        return self._store_pixels
+
+    @store_pixels.setter
+    def store_pixels(self, store_pixels):
+        """setter for store pixels
+
+        calls update_pixels after store_pixels is set if needed
+        """
+        # only update if value is changed
+        do_update = False if store_pixels == self._store_pixels else True
+        self._store_pixels = store_pixels
+        if do_update:
+            self.update_pixels()
+
+    @property
+    def ignore_zero_weight(self):
+        """getter for ignore_zero_weight attribute"""
+        return self._ignore_zero_weight
+
+    @ignore_zero_weight.setter
+    def ignore_zero_weight(self, ignore_zero_weight):
+        """setter for ignore_zero_weight
+
+        calls update_pixels after ignore_zero_weight is set if needed
+        """
+        do_update = False if ignore_zero_weight == self._ignore_zero_weight else True
+        self._ignore_zero_weight = ignore_zero_weight
+        if do_update:
+            self.update_pixels()
 
     def update_pixels(self):
         """

--- a/ngmix/tests/test_observation.py
+++ b/ngmix/tests/test_observation.py
@@ -502,6 +502,24 @@ def test_observation_set_store_pixels(image_data):
     obs.store_pixels = True
     assert obs.pixels is not None
 
+    obs = Observation(
+        image=image_data['image'],
+        store_pixels=False,
+    )
+    with obs.writeable():
+        assert obs.pixels is None
+        obs.store_pixels = True
+        # we force an update here since this change should be expected
+        assert obs.pixels is not None
+
+        obs.store_pixels = False
+        assert obs.pixels is None
+
+        obs.store_pixels = True
+
+    # final state should be this
+    assert obs.pixels is not None
+
 
 def test_observation_set_ignore_zero_weight(image_data):
     wgt = image_data["weight"].copy()
@@ -531,4 +549,26 @@ def test_observation_set_ignore_zero_weight(image_data):
     obs.ignore_zero_weight = True
     assert len(obs.pixels) == wgt.size-4
     obs.ignore_zero_weight = False
+    assert len(obs.pixels) == wgt.size
+
+    obs = Observation(
+        image=image_data['image'],
+        weight=wgt,
+        store_pixels=True,
+        ignore_zero_weight=True,
+    )
+    with obs.writeable():
+        assert obs.pixels is not None
+        assert len(obs.pixels) == wgt.size-4
+
+        # we force a change here since this is expected
+        obs.ignore_zero_weight = False
+        assert len(obs.pixels) == wgt.size
+
+        obs.ignore_zero_weight = True
+        assert len(obs.pixels) == wgt.size-4
+
+        obs.ignore_zero_weight = False
+
+    # final state should be this
     assert len(obs.pixels) == wgt.size

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
+import os
 from setuptools import setup, find_packages
+
+__version__ = None
+pth = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "ngmix",
+    "_version.py")
+with open(pth, 'r') as fp:
+    exec(fp.read())
 
 setup(
     name="ngmix",
@@ -6,5 +15,5 @@ setup(
     url="https://github.com/esheldon/ngmix",
     description="fast 2-d gaussian mixtures for modeling astronomical images",
     packages=find_packages(exclude=["mdet_tests"]),
-    version="2.0.0rc1",
+    version=__version__,
 )


### PR DESCRIPTION
This PR 

 - allows store pixels and ignore zero weight to be changed for observations
 - propagates these values when observations are copied (breaking API change)
 - moves the version to be stored in one spot
 - bumps the version to 2.0.0rc2
 - put manual flux scaling in mdet regression tests