### PR TITLE
BUG fix rendering bug in metacal; bump to 1.3.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## v1.3.9
+
+### bug fixes
+
+- metacal was reconvolving by the pixel *twice*, which resulted in larger
+  reconvolved PSFs and thus somewhat lower, but still accurate, response than
+  the pixel was included once. This did not cause any bias. 
+
 ## v1.3.8
 
 ### bug fixes

--- a/ngmix/__init__.py
+++ b/ngmix/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.3.8'
+__version__ = 'v1.3.9'
 
 from . import gmix
 from .gmix import (

--- a/ngmix/metacal.py
+++ b/ngmix/metacal.py
@@ -577,6 +577,7 @@ class Metacal(object):
                 ny=ny,
                 wcs=self.image.wcs,
                 dtype=numpy.float64,
+                method='no_pixel',
             )
         except RuntimeError as err:
             # argh, galsim uses generic exceptions

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     url="https://github.com/esheldon/ngmix",
     description="fast 2-d gaussian mixtures for modeling astronomical images",
     packages=['ngmix', 'ngmix.tests'],
-    version="1.3.8",
+    version="1.3.9",
     cmdclass={'build_py': build_py},
 )


### PR DESCRIPTION
This PR fixes the same bug reported in #160 but for the 1.3.x series. I am merging it into a 1.3.x release branch we can use to release 1.3.9 with the fix. 