### PR TITLE
Metacal psf cache bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
   EMFitterFixCov, or equivalently the fixcov=True keyword to the run_em
   convenience function
 
+### bug fixes
+
+- fixed bug with sheared psfs in metacal, negative sheared psfs
+  were not being cached.
+
 ## v2.0.0
 
 ### breaking API changes

--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -274,8 +274,10 @@ class MetacalDilatePSF(object):
         return self._psf_cache[key]
 
     def _get_psf_key(self, shear, doshear):
-        g = np.sqrt(shear.g1**2 + shear.g2**2)
-        return '%s-%s' % (doshear, g)
+        """
+        need full g1 and g2 in key to support psf shearing
+        """
+        return '%s-%s-%s' % (doshear, shear.g1, shear.g2)
 
     def get_target_image(self, psf_obj, shear=None):
         """

--- a/ngmix/tests/test_metacal.py
+++ b/ngmix/tests/test_metacal.py
@@ -32,6 +32,15 @@ def test_metacal_smoke(psf):
         assert mobs.psf.image.shape == obs.psf.image.shape
         assert np.all(mobs.psf.image != obs.psf.image)
 
+    assert np.all(obs_dict['1p'].image != obs_dict['1m'].image)
+    assert np.all(obs_dict['2p'].image != obs_dict['2m'].image)
+    assert np.all(obs_dict['noshear'].image != obs_dict['1p'].image)
+
+    if psf == 'dilate':
+        assert np.all(obs_dict['1p_psf'].image != obs_dict['1m_psf'].image)
+        assert np.all(obs_dict['2p_psf'].image != obs_dict['2m_psf'].image)
+        assert np.all(obs_dict['noshear'].image != obs_dict['2m_psf'].image)
+
 
 @pytest.mark.parametrize('psf', ['gauss', 'fitgauss', 'galsim_obj', 'dilate'])
 def test_metacal_types_smoke(psf):


### PR DESCRIPTION
fix bug where sheared psf was not cached properly

was only caching based on |g|
