### PR TITLE
Add option to fit center only in adaptive moments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## unreleased
+## v2.0.2 (unreleased)
 
 ### new features
 
@@ -9,6 +9,14 @@
   fitters for using just those quantities.
 - Added `FFTRangeError` which is now raised if `KSigmaMom` or `PrePSFGaussMom`
   are using inconsistent FFT sizes given the kernel size.
+- add `cenonly` option to adaptive moments, using a fixed gaussian covariance
+  with only the center varying.  Added ngmix.admom.find_cen_admom function
+  for finding the center.
+
+### bug fixes
+
+- Fixed bug identifying that adaptive moments had reached maximum
+  number of iterations
 
 ## v2.0.1
 

--- a/ngmix/_version.py
+++ b/ngmix/_version.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.1'  # noqa
+__version__ = '2.0.2'  # noqa

--- a/ngmix/admom/admom.py
+++ b/ngmix/admom/admom.py
@@ -88,14 +88,17 @@ def find_cen_admom(
     ----------
     obs: Observation
         ngmix.Observation
-    gmix: ngmix.GMix*
-        A weight function.  On the first iteration the center of this
-        gmix is used for the guess, on subsequent tries a guess is
-        generated as a uniform deviate within a pixel scale.
-    fwhm: ngmix.GMix*
+    gmix: ngmix.GMix*, optional
+        A gaussian weight function.  Can be created with ngmix.GMixModel with
+        model 'gauss' or with ngmix.GMix with parameters for a single gaussian.
+        On the first iteration the center of this gmix is used for the guess,
+        on subsequent tries a guess is generated as a uniform deviate within a
+        pixel scale.  Send either gmix= or fwhm=
+    fwhm: float, optional
         The fwhm for a gaussian weight function.  On the first iteration the
         center of the jacobian is used for the guess, on subsequent tries a
         guess is generated as a uniform deviate within a pixel scale.
+        Send either gmix= or fwhm=
     maxiter: integer, optional
         Maximum number of iterations, default 200
     etol: float, optional

--- a/ngmix/admom/admom.py
+++ b/ngmix/admom/admom.py
@@ -1,9 +1,10 @@
-__all__ = ['run_admom', 'AdmomFitter']
+__all__ = ['run_admom', 'find_cen_admom', 'AdmomFitter']
 
-import numpy
+import numpy as np
 from numpy import diag
 
 from ..gmix import GMix, GMixModel
+from ..moments import fwhm_to_T
 from ..shape import e1e2_to_g1g2
 from ..observation import Observation
 from ..gexceptions import GMixRangeError
@@ -21,9 +22,14 @@ def run_admom(
     shiftmax=DEFAULT_SHIFTMAX,
     etol=DEFAULT_ETOL,
     Ttol=DEFAULT_TTOL,
+    cenonly=False,
     rng=None,
 ):
     """
+    Run adaptive moments on the observation
+
+    Parameters
+    ----------
     obs: Observation
         ngmix.Observation
     guess: ngmix.GMix or a float
@@ -42,9 +48,15 @@ def run_admom(
         Largest allowed shift in the centroid, relative to
         the initial guess.  Default 5.0 (5 pixels if the jacobian
         scale is 1)
-    rng: numpy.random.RandomState
+    cenonly: bool, optional
+        If set to True, only fit for the center
+    rng: np.random.RandomState
         Random state for creating full gaussian guesses based
         on a T guess
+
+    Returns
+    -------
+    AdmomResult
     """
 
     am = AdmomFitter(
@@ -52,9 +64,100 @@ def run_admom(
         shiftmax=shiftmax,
         etol=etol,
         Ttol=Ttol,
+        cenonly=cenonly,
         rng=rng,
     )
     return am.go(obs=obs, guess=guess)
+
+
+def find_cen_admom(
+    obs,
+    fwhm=None,
+    gmix=None,
+    maxiter=DEFAULT_MAXITER,
+    shiftmax=DEFAULT_SHIFTMAX,
+    etol=DEFAULT_ETOL,
+    Ttol=DEFAULT_TTOL,
+    ntry=1,
+    rng=None,
+):
+    """
+    Use adaptive moments with fixed weight function to find the center
+
+    Parameters
+    ----------
+    obs: Observation
+        ngmix.Observation
+    gmix: ngmix.GMix*
+        A weight function.  On the first iteration the center of this
+        gmix is used for the guess, on subsequent tries a guess is
+        generated as a uniform deviate within a pixel scale.
+    fwhm: ngmix.GMix*
+        The fwhm for a gaussian weight function.  On the first iteration the
+        center of the jacobian is used for the guess, on subsequent tries a
+        guess is generated as a uniform deviate within a pixel scale.
+    maxiter: integer, optional
+        Maximum number of iterations, default 200
+    etol: float, optional
+        absolute tolerance in e1 or e2 to determine convergence,
+        default 1.0e-5
+    Ttol: float, optional
+        relative tolerance in T <x^2> + <y^2> to determine
+        convergence, default 1.0e-3
+    shiftmax: float, optional
+        Largest allowed shift in the centroid, relative to the initial guess.
+        Default 5.0 (5 pixels if the jacobian scale is 1)
+    rng: np.random.RandomState
+        Random state, required if more than one try is requested in order
+        to generate guesses.
+
+    Returns
+    -------
+    AdmomResult with entry "cen" set.  This cen is the offset relative to
+    the jacobian center
+    """
+
+    if ntry > 1 and rng is None:
+        raise ValueError(
+            'send a random number generator rng= when trying more than once '
+            'this facilitates generating a new guess for the center'
+        )
+
+    if gmix is not None:
+        wt = gmix.copy()
+    elif fwhm is not None:
+        T = fwhm_to_T(fwhm)
+        pars = [0.0, 0.0, 0.0, 0.0, T, 1.0]
+        wt = GMixModel(pars, 'gauss')
+    else:
+        raise ValueError('send gmix= or fwhm=')
+
+    scale = obs.jacobian.scale
+
+    am = AdmomFitter(
+        maxiter=maxiter,
+        shiftmax=shiftmax,
+        etol=etol,
+        Ttol=Ttol,
+        cenonly=True,
+    )
+
+    for itry in range(ntry):
+        res = am.go(obs=obs, guess=wt)
+        if res['flags'] == 0:
+            break
+
+        if ntry > 1:
+            # offset from jacobian center
+            drow, dcol = rng.uniform(low=-scale/2, high=scale/2, size=2)
+            wt.set_cen(row=drow, col=dcol)
+
+    if res['flags'] == 0:
+        res['cen'] = res.get_gmix().get_cen()
+    else:
+        res['cen'] = np.zeros(2) + np.nan
+
+    return res
 
 
 class AdmomResult(dict):
@@ -136,7 +239,9 @@ class AdmomFitter(object):
         Largest allowed shift in the centroid, relative to
         the initial guess.  Default 5.0 (5 pixels if the jacobian
         scale is 1)
-    rng: numpy.random.RandomState
+    cenonly: bool, optional
+        If set to True, only vary the center
+    rng: np.random.RandomState
         Random state for creating full gaussian guesses based
         on a T guess
     """
@@ -146,9 +251,16 @@ class AdmomFitter(object):
                  shiftmax=DEFAULT_SHIFTMAX,
                  etol=DEFAULT_ETOL,
                  Ttol=DEFAULT_TTOL,
+                 cenonly=False,
                  rng=None):
 
-        self._set_conf(maxiter, shiftmax, etol, Ttol)
+        self._set_conf(
+            maxiter=maxiter,
+            shiftmax=shiftmax,
+            etol=etol,
+            Ttol=Ttol,
+            cenonly=cenonly,
+        )
 
         self.rng = rng
 
@@ -197,24 +309,25 @@ class AdmomFitter(object):
             guess_gmix = self._generate_guess(obs=obs, Tguess=Tguess)
         return guess_gmix
 
-    def _set_conf(self, maxiter, shiftmax, etol, Ttol):  # noqa
-        dt = numpy.dtype(_admom_conf_dtype, align=True)
-        conf = numpy.zeros(1, dtype=dt)
+    def _set_conf(self, maxiter, shiftmax, etol, Ttol, cenonly):  # noqa
+        dt = np.dtype(_admom_conf_dtype, align=True)
+        conf = np.zeros(1, dtype=dt)
 
         conf['maxit'] = maxiter
         conf['shiftmax'] = shiftmax
         conf['etol'] = etol
         conf['Ttol'] = Ttol
+        conf['cenonly'] = cenonly
 
         self.conf = conf
 
     def _get_am_result(self):
-        dt = numpy.dtype(_admom_result_dtype, align=True)
-        return numpy.zeros(1, dtype=dt)
+        dt = np.dtype(_admom_result_dtype, align=True)
+        return np.zeros(1, dtype=dt)
 
     def _get_rng(self):
         if self.rng is None:
-            self.rng = numpy.random.RandomState()
+            self.rng = np.random.RandomState()
 
         return self.rng
 
@@ -223,7 +336,7 @@ class AdmomFitter(object):
         rng = self._get_rng()
 
         scale = obs.jacobian.get_scale()
-        pars = numpy.zeros(6)
+        pars = np.zeros(6)
         pars[0:0+2] = rng.uniform(low=-0.5*scale, high=0.5*scale, size=2)
         pars[2:2+2] = rng.uniform(low=-0.3, high=0.3, size=2)
         pars[4] = Tguess*(1.0 + rng.uniform(low=-0.1, high=0.1))
@@ -238,7 +351,7 @@ def get_result(ares):
     calculate a few more things
     """
 
-    if isinstance(ares, numpy.ndarray):
+    if isinstance(ares, np.ndarray):
         ares = ares[0]
         names = ares.dtype.names
     else:
@@ -255,7 +368,7 @@ def get_result(ares):
 
     res['flux_mean'] = -9999.0
     res['s2n'] = -9999.0
-    res['e'] = numpy.array([-9999.0, -9999.0])
+    res['e'] = np.array([-9999.0, -9999.0])
     res['e_err'] = 9999.0
 
     if res['flags'] == 0:
@@ -300,8 +413,8 @@ def get_result(ares):
                 sums_cov[3, 4],
             )
 
-            if (not numpy.isfinite(res['e1err']) or
-                    not numpy.isfinite(res['e2err'])):
+            if (not np.isfinite(res['e1err']) or
+                    not np.isfinite(res['e2err'])):
                 res['e1err'] = 9999.0
                 res['e2err'] = 9999.0
                 res['e_cov'] = diag([9999.0, 9999.0])
@@ -315,7 +428,7 @@ def get_result(ares):
 
         if fvar_sum > 0.0:
 
-            flux_err = numpy.sqrt(fvar_sum)
+            flux_err = np.sqrt(fvar_sum)
             res['s2n'] = flux_sum/flux_err
 
             # error on each shape component from BJ02 for gaussians
@@ -349,6 +462,7 @@ _admom_conf_dtype = [
     ('shiftmax', 'f8'),
     ('etol', 'f8'),
     ('Ttol', 'f8'),
+    ('cenonly', bool),
 ]
 
 _admom_flagmap = {

--- a/ngmix/admom/admom_nb.py
+++ b/ngmix/admom/admom_nb.py
@@ -96,15 +96,16 @@ def admom(confarray, wt, pixels, resarray):
         else:
             # deweight moments and go to the next iteration
 
-            deweight_moments(wt, Irr, Irc, Icc, res)
-            if res['flags'] != 0:
-                break
+            if not conf['cenonly']:
+                deweight_moments(wt, Irr, Irc, Icc, res)
+                if res['flags'] != 0:
+                    break
 
             e1old = e1
             e2old = e2
             Told = T
 
-    res['numiter'] = i
+    res['numiter'] = i+1
 
     if res['numiter'] == conf['maxit']:
         res['flags'] = ADMOM_MAXIT

--- a/ngmix/tests/test_admom.py
+++ b/ngmix/tests/test_admom.py
@@ -4,9 +4,6 @@ import numpy as np
 import pytest
 
 import ngmix
-from ngmix import Jacobian
-from ngmix.admom import run_admom
-from ngmix import Observation
 from ngmix.moments import fwhm_to_T
 
 
@@ -14,7 +11,7 @@ from ngmix.moments import fwhm_to_T
 @pytest.mark.parametrize('wcs_g2', [-0.2, 0, 0.5])
 @pytest.mark.parametrize('g1_true', [-0.1, 0, 0.2])
 @pytest.mark.parametrize('g2_true', [-0.2, 0, 0.1])
-def test_admom_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
+def test_admom(g1_true, g2_true, wcs_g1, wcs_g2):
     rng = np.random.RandomState(seed=100)
 
     fwhm = 0.9
@@ -55,19 +52,19 @@ def test_admom_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
             dtype=np.float64,
         ).array
 
-        jac = Jacobian(
+        jac = ngmix.Jacobian(
             y=cen + xy.y, x=cen + xy.x,
             dudx=gs_wcs.dudx, dudy=gs_wcs.dudy,
             dvdx=gs_wcs.dvdx, dvdy=gs_wcs.dvdy)
 
         _im = im + (rng.normal(size=im.shape) * noise)
-        obs = Observation(
+        obs = ngmix.Observation(
             image=_im,
             weight=wgt,
             jacobian=jac)
 
         Tguess = fwhm_to_T(fwhm) + rng.normal()*0.01
-        res = run_admom(obs=obs, guess=Tguess)
+        res = ngmix.admom.run_admom(obs=obs, guess=Tguess)
 
         if res['flags'] == 0:
             gm = res.get_gmix()
@@ -97,7 +94,7 @@ def test_admom_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
         assert np.abs(T - fwhm_to_T(fwhm)) < 1e-6
 
     with pytest.raises(ValueError):
-        _ = run_admom(None, None)
+        _ = ngmix.admom.run_admom(None, None)
 
     # cover some branches
     tres = copy.deepcopy(res)
@@ -112,3 +109,98 @@ def test_admom_smoke(g1_true, g2_true, wcs_g1, wcs_g2):
     tres['pars'][4] = -1
     tres = ngmix.admom.admom.get_result(tres)
     assert tres['flags'] == 0x8
+
+
+@pytest.mark.parametrize('snr', [20, 10, 5])
+@pytest.mark.parametrize('g1_true', [0, 0.2])
+@pytest.mark.parametrize('g2_true', [-0.2, 0])
+def test_admom_find_cen(g1_true, g2_true, snr):
+    """
+    test that the center is right within expected errors, and that the fit is
+    robust.  We expect a failure rate less than 0.3 percent
+    """
+    rng = np.random.RandomState(seed=55)
+    ntrial = 1000
+    ntry = 2
+
+    bd = galsim.BaseDeviate(seed=rng.randint(0, 2**31))
+    gsnoise = galsim.GaussianNoise(bd)
+
+    psf_fwhm = 0.8
+    gal_hlr = 0.5
+    image_size = 48
+    cen = (image_size - 1)/2
+    scale = 0.2
+    shift_scale = scale/2
+
+    psf = galsim.Gaussian(fwhm=psf_fwhm)
+
+    weight_fwhm = 1.2
+    drow_arr = []
+    dcol_arr = []
+    for _ in range(ntrial):
+        drow, dcol = rng.uniform(
+            low=-shift_scale,
+            high=shift_scale,
+            size=2,
+        )
+
+        obj = galsim.Exponential(
+            half_light_radius=gal_hlr,
+        ).shift(
+            dcol, drow,
+        ).shear(
+            g1=g1_true, g2=g2_true
+        )
+
+        obj = galsim.Convolve(obj, psf)
+
+        gsim = obj.drawImage(
+            nx=image_size,
+            ny=image_size,
+            scale=scale,
+        )
+        noise_var = gsim.addNoiseSNR(noise=gsnoise, snr=snr)
+
+        im = gsim.array
+
+        wgt = np.ones_like(im) / noise_var
+
+        jac = ngmix.DiagonalJacobian(row=cen, col=cen, scale=scale)
+
+        obs = ngmix.Observation(
+            image=im,
+            weight=wgt,
+            jacobian=jac,
+        )
+
+        for itrial in range(ntry):
+
+            res = ngmix.admom.find_cen_admom(
+                obs=obs, fwhm=weight_fwhm, rng=rng, ntry=4,
+            )
+            if res['flags'] == 0:
+                break
+
+        if res['flags'] == 0:
+            gm = res.get_gmix()
+            drow_meas, dcol_meas = gm.get_cen()
+
+            drow_arr.append(drow_meas - drow)
+            dcol_arr.append(dcol_meas - dcol)
+
+    frac_fail = len(drow_arr)/ntrial - 1
+
+    assert abs(frac_fail) < 0.003
+
+    drow_arr = np.hstack(drow_arr)
+    dcol_arr = np.hstack(dcol_arr)
+
+    drow_mean = drow_arr.mean()
+    dcol_mean = dcol_arr.mean()
+
+    drow_err = drow_arr.std()/np.sqrt(drow_arr.size)
+    dcol_err = dcol_arr.std()/np.sqrt(dcol_arr.size)
+
+    assert np.abs(drow_mean)/drow_err < 5, (drow_mean/drow_err)
+    assert np.abs(dcol_mean)/dcol_err < 5, (dcol_mean/dcol_err)


### PR DESCRIPTION
closes #180 

Adds option for adaptive moments `cenonly=True` to only vary the center.  Adds new function `ngmix.admom.find_cen_admom`