### PR TITLE
BUG fix buggy admom usage in metacal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
     - Changes to ensure the "flux" result from the `AdmomFitter` is normalized
       the same as those from the other moments fitters.
+    - In MetacalFitGaussPSF when using adaptive moments to get the psf
+      model, be careful to use the fitted parameters rather than going through
+      an intermediate gmix, which converts e1, e2 to g1, g2 and can fail in
+      rare cases.
 
 ## v2.0.3
 

--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -691,8 +691,13 @@ class MetacalFitGaussPSF(MetacalGaussPSF):
                     # ok, just raise and exception
                     raise BootPSFFailure('failed to fit psf '
                                          'for MetacalFitGaussPSF')
-
-            e1, e2, T = psf_gmix.get_e1e2T()
+            try:
+                e1, e2, T = psf_gmix.get_e1e2T()
+            except GMixRangeError as err:
+                logger.info('%s', err)
+                raise BootPSFFailure(
+                    'could not get e1,e2 from psf fit for MetacalFitGaussPSF'
+                )
 
         dilation = _get_ellip_dilation(e1, e2, T)
         T_dilated = T*dilation

--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -661,7 +661,8 @@ class MetacalFitGaussPSF(MetacalGaussPSF):
         res = run_psf_fitter(obs=psfobs, fitter=fitter, guesser=guesser, ntry=ntry)
 
         if res['flags'] == 0:
-            psf_gmix = res.get_gmix()
+            e1, e2 = res['e']
+            T = res['T']
         else:
             # try maximum likelihood
 
@@ -691,7 +692,7 @@ class MetacalFitGaussPSF(MetacalGaussPSF):
                     raise BootPSFFailure('failed to fit psf '
                                          'for MetacalFitGaussPSF')
 
-        e1, e2, T = psf_gmix.get_e1e2T()
+            e1, e2, T = psf_gmix.get_e1e2T()
 
         dilation = _get_ellip_dilation(e1, e2, T)
         T_dilated = T*dilation


### PR DESCRIPTION
     In MetacalFitGaussPSF when using adaptive moments to get the psf
     model, be careful to use the fitted parameters rather than going
     through an intermediate gmix, which converts e1, e2 to g1, g2 and
     can fail in rare cases.