### PR TITLE
BUG missing flags; better flux norm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
       model, be careful to use the fitted parameters rather than going through
       an intermediate gmix, which converts e1, e2 to g1, g2 and can fail in
       rare cases.
-    - Some AdmomFitter failures were mot being flagged properly.
+    - Some AdmomFitter failures were not being flagged properly.
 
 ## v2.0.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
       model, be careful to use the fitted parameters rather than going through
       an intermediate gmix, which converts e1, e2 to g1, g2 and can fail in
       rare cases.
+    - Some AdmomFitter failures were mot being flagged properly.
 
 ## v2.0.3
 

--- a/ngmix/admom/admom.py
+++ b/ngmix/admom/admom.py
@@ -303,9 +303,7 @@ class AdmomFitter(object):
         except GMixRangeError:
             ares['flags'] = ngmix.flags.GMIX_RANGE_ERROR
 
-        # admom fills in the det
-        wgt_norm = 1.0 / (2 * np.pi * np.sqrt(wt_gmix["det"]))
-        result = get_result(ares, obs.jacobian.area, wgt_norm)
+        result = get_result(ares, obs.jacobian.area, wt_gmix["norm"][0])
 
         return AdmomResult(obs=obs, result=result)
 

--- a/ngmix/tests/test_admom.py
+++ b/ngmix/tests/test_admom.py
@@ -103,13 +103,13 @@ def test_admom(g1_true, g2_true, wcs_g1, wcs_g2):
 
     tres['flags'] = 0
     tres['sums_cov'][:, :] = np.nan
-    tres = ngmix.admom.admom.get_result(tres, 1.0)
+    tres = ngmix.admom.admom.get_result(tres, 1.0, 1.0)
     assert np.isnan(tres['e1err'])
 
     tres = copy.deepcopy(res)
     tres['flags'] = 0
     tres['pars'][4] = -1
-    tres = ngmix.admom.admom.get_result(tres, 1.0)
+    tres = ngmix.admom.admom.get_result(tres, 1.0, 1.0)
     assert tres['flags'] == ngmix.flags.NONPOS_SIZE
 
 


### PR DESCRIPTION
It appears that I messed up the flags in the recent admom change. I also found a better way to match the flux normalization. The old way threw errors sometimes for reasons I did not follow. 