### PR TITLE
ENH add extra conv and deconv ops to prepsf moments

### DIFF
--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -6,6 +6,8 @@ significantly.
 """
 import copy
 import logging
+from functools import lru_cache
+
 import numpy as np
 from ..gexceptions import GMixRangeError, BootPSFFailure
 from ..shape import Shape
@@ -18,6 +20,14 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=128)
+def _cached_galsim_stuff(img, wcs_repr, xinterp):
+    import galsim
+    image = galsim.Image(np.array(img), wcs=eval(wcs_repr))
+    image_int = galsim.InterpolatedImage(image, x_interpolant=xinterp)
+    return image, image_int
 
 
 class MetacalDilatePSF(object):
@@ -355,21 +365,23 @@ class MetacalDilatePSF(object):
         # these would share data with the original numpy arrays, make copies
         # to be sure they don't get modified
         #
-        self.image = galsim.Image(obs.image.copy(),
-                                  wcs=self.get_wcs())
+        image, image_int = _cached_galsim_stuff(
+            tuple(tuple(ii) for ii in obs.image.copy()),
+            repr(self.get_wcs()),
+            self.interp,
+        )
+        self.image = image
+        self.image_int = image_int
 
-        self.psf_image = galsim.Image(obs.psf.image.copy(),
-                                      wcs=self.get_psf_wcs())
-
-        # interpolated psf image
-        psf_int = galsim.InterpolatedImage(self.psf_image,
-                                           x_interpolant=self.interp)
+        psf_image, psf_int = _cached_galsim_stuff(
+            tuple(tuple(ii) for ii in obs.psf.image.copy()),
+            repr(self.get_psf_wcs()),
+            self.interp,
+        )
+        self.psf_image = psf_image
 
         # this can be used to deconvolve the psf from the galaxy image
         psf_int_inv = galsim.Deconvolve(psf_int)
-
-        self.image_int = galsim.InterpolatedImage(self.image,
-                                                  x_interpolant=self.interp)
 
         # deconvolved galaxy image, psf+pixel removed
         self.image_int_nopsf = galsim.Convolve(self.image_int,

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -456,7 +456,7 @@ def _zero_pad_and_compute_fft_cached_list(psf_obs_list, kim, target_dim):
         ]
         kpsf_im = np.prod([f[0] for f in fft_res], axis=0)
         psf_im_row = sum([f[1] for f in fft_res])
-        psf_im_row = sum([f[2] for f in fft_res])
+        psf_im_col = sum([f[2] for f in fft_res])
 
     return kpsf_im, psf_im_row, psf_im_col
 

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -712,26 +712,20 @@ def _check_obs_and_get_psf_obs(
     if not obs.has_psf() and not no_psf:
         raise RuntimeError("The PSF must be set to measure a pre-PSF moment!")
 
-    if no_psf and (extra_conv_psfs or extra_deconv_psfs):
-        raise RuntimeError(
-            "You can only use extra conv. or deconv. PSFs with observations "
-            "that have a PSF!"
-        )
-
     if not no_psf:
         conv_psfs = extra_conv_psfs or []
         deconv_psfs = [obs.get_psf()] + (extra_deconv_psfs or [])
-
-        if any(
-            not _jacobian_close(psf_obs.jacobian, obs.jacobian)
-            for psf_obs in conv_psfs + deconv_psfs
-        ):
-            raise RuntimeError(
-                "The PSF and observation must have the same WCS "
-                "Jacobian for measuring pre-PSF moments."
-            )
     else:
-        conv_psfs = []
-        deconv_psfs = []
+        conv_psfs = extra_conv_psfs or []
+        deconv_psfs = extra_deconv_psfs or []
+
+    if any(
+        not _jacobian_close(psf_obs.jacobian, obs.jacobian)
+        for psf_obs in conv_psfs + deconv_psfs
+    ):
+        raise RuntimeError(
+            "The PSF and observation must have the same WCS "
+            "Jacobian for measuring pre-PSF moments."
+        )
 
     return conv_psfs, deconv_psfs

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -692,6 +692,13 @@ def _gauss_kernels(
     )
 
 
+def _jacobian_close(jac1, jac2):
+    return np.allclose(
+        [jac1.dudcol, jac1.dudrow, jac1.dvdcol, jac1.dvdrow],
+        [jac2.dudcol, jac2.dudrow, jac2.dvdcol, jac2.dvdrow]
+    )
+
+
 def _check_obs_and_get_psf_obs(
     obs, no_psf, extra_conv_psfs=None, extra_deconv_psfs=None,
 ):
@@ -716,7 +723,7 @@ def _check_obs_and_get_psf_obs(
         deconv_psfs = [obs.get_psf()] + (extra_deconv_psfs or [])
 
         if any(
-            psf_obs.jacobian.get_galsim_wcs() != obs.jacobian.get_galsim_wcs()
+            not _jacobian_close(psf_obs.jacobian, obs.jacobian)
             for psf_obs in conv_psfs + deconv_psfs
         ):
             raise RuntimeError(

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -751,6 +751,8 @@ def test_prepsfmom_gauss_true_flux_T(
     pad_factor, psf_image_size, image_size, fwhm, psf_fwhm, pixel_scale,
     cls, extra_psf_fwhm
 ):
+    """This test ensures the kernels are normalize properly so
+    we have the correct total flux, etc."""
     rng = np.random.RandomState(seed=100)
     snr = 1e8
     mom_fwhm = 15.0
@@ -779,6 +781,8 @@ def test_prepsfmom_gauss_true_flux_T(
     res = fitter.go(obs=obs, no_psf=True)
     flux_true = res["flux"]
     T_true = res["T"]
+    g1_true = res["e1"]
+    g2_true = res["e2"]
     assert np.allclose(flux_true, 400, atol=0, rtol=5e-3)
 
     if extra_psf_fwhm is None:
@@ -792,6 +796,8 @@ def test_prepsfmom_gauss_true_flux_T(
         flux_true = res["flux"]
         assert np.allclose(flux_true, 400, atol=0, rtol=5e-3)
         assert np.allclose(res["T"], T_true, atol=0, rtol=5e-4)
+        assert np.allclose(res["e1"], g1_true, atol=5e-3, rtol=5e-3)
+        assert np.allclose(res["e2"], g2_true, atol=5e-3, rtol=5e-3)
     else:
         # this should fail since it is the wrong PSF
         obs = Observation(
@@ -806,6 +812,8 @@ def test_prepsfmom_gauss_true_flux_T(
         flux_true = res["flux"]
         # we use a big relative difference since the T should be way off
         assert not np.allclose(res["T"], T_true, atol=0, rtol=1e-1)
+        assert not np.allclose(res["e1"], g1_true, atol=0, rtol=1e-1)
+        assert not np.allclose(res["e2"], g2_true, atol=0, rtol=1e-1)
 
         # this should work since we have the PSF correction in there
         obs = Observation(
@@ -827,6 +835,8 @@ def test_prepsfmom_gauss_true_flux_T(
         flux_true = res["flux"]
         assert np.allclose(flux_true, 400, atol=0, rtol=5e-3)
         assert np.allclose(res["T"], T_true, atol=0, rtol=5e-4)
+        assert np.allclose(res["e1"], g1_true, atol=5e-3, rtol=5e-3)
+        assert np.allclose(res["e2"], g2_true, atol=5e-3, rtol=5e-3)
 
 
 @pytest.mark.parametrize('pixel_scale', [0.25, 0.125])

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -221,6 +221,9 @@ def test_prepsfmom_speed_and_cache():
     ).array
 
     # now we test the speed + caching
+    _gauss_kernels.cache_clear()
+    _zero_pad_and_compute_fft_cached_impl.cache_clear()
+
     # the first fit will do numba stuff, so we exclude it
     # we also perturb the various inputs to fool our caches
     fitter = PGaussMom(

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -200,7 +200,6 @@ def test_prepsfmom_speed_and_cache():
     assert _zero_pad_and_compute_fft_cached_impl.cache_info().misses == 1
 
     # the second fit will have numba cached, but not the other kernel and FFT caches
-    # we also perturb the various inputs to fool our caches
     fitter = PGaussMom(
         fwhm=mom_fwhm,
     )
@@ -222,7 +221,7 @@ def test_prepsfmom_speed_and_cache():
     assert _gauss_kernels.cache_info().misses == 2
     assert _zero_pad_and_compute_fft_cached_impl.cache_info().misses == 2
 
-    # we test with full caching
+    # now we test with full caching
     nfit = 1000
     dt = time.time()
     for _ in range(nfit):

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -777,7 +777,7 @@ def test_moments_make_mom_result_flags():
 @pytest.mark.parametrize('image_size', [250])
 @pytest.mark.parametrize('psf_image_size', [33, 34])
 @pytest.mark.parametrize('pad_factor', [4, 3.5])
-def test_prepsfmom_gauss_true_flux(
+def test_prepsfmom_gauss_true_flux_T(
     pad_factor, psf_image_size, image_size, fwhm, psf_fwhm, pixel_scale,
     cls, extra_psf_fwhm
 ):

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -194,7 +194,7 @@ def _run_prepsfmom_sims(sdata, fitter, rng, nitr):
     g2_true = res["e"][1]
 
     no_psf = sdata["psf_im"] is None
-    if sdata["extra_psf_fwhm"] is not None:
+    if sdata["extra_psf_im"] is not None:
         assert not no_psf
 
     res = []


### PR DESCRIPTION
This PR does a few things.

- [x] adds caching to some of the pre-PSF moment functions
- [x] adds support for extra conv and deconv PSFs for pre-PSF moments
- [x] tests for all of the above