### PR TITLE
ENH add moment weight sums to output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,11 @@
 ## v2.1.0
 
-### bug fixes
-
-    - Fixed bug in computing `mom` and `mom_cov` fields for weighted Gaussian moments.
-
 ### new features
 
     - Added `fwhm_smooth` keyword to pre-PSF moments routines to allow for extra
       smoothing of the profile before the moments are measured.
     - Added caching of FFTs in metacal and pre-PSF moment rountines.
+    - Added moments weight function normalization.
 
 
 ## v2.0.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## v2.1.0
 
+### bug fixes
+
+    - Fixed bug in computing `mom` and `mom_cov` fields for weighted Gaussian moments.
+
 ### new features
 
     - Added `fwhm_smooth` keyword to pre-PSF moments routines to allow for extra

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,9 @@
 ### bug fixes
 
     - Fixed 1/area normalization for all moments fields in `GaussMom` results.
+### changes
 
+    - Changed "mom*" fields in the moments outputs to "sums*".
 ### new features
 
     - Added `fwhm_smooth` keyword to pre-PSF moments routines to allow for extra

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -232,8 +232,10 @@ def test_mdet_regression(fname, write=False):
     else:
         old_data = fitsio.read(fname)
         for col in old_data.dtype.names:
-            if ('psf_' in col or 'ratio' in col) and (
-                '1.3.9' in fname or '2.0' in fname):
+            if (
+                ('psf_' in col or 'ratio' in col)
+                and ('1.3.9' in fname or '2.0' in fname)
+            ):
                 rtol = 1.0e-4
                 atol = 1.0e-4
             else:

--- a/mdet_tests/test_mdet_regression.py
+++ b/mdet_tests/test_mdet_regression.py
@@ -232,7 +232,8 @@ def test_mdet_regression(fname, write=False):
     else:
         old_data = fitsio.read(fname)
         for col in old_data.dtype.names:
-            if ('psf_' in col or 'ratio' in col) and '1.3.9' in fname:
+            if ('psf_' in col or 'ratio' in col) and (
+                '1.3.9' in fname or '2.0' in fname):
                 rtol = 1.0e-4
                 atol = 1.0e-4
             else:

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -58,13 +58,11 @@ class GaussMom(object):
         res['flux'] *= fac
         res['flux_err'] *= fac
         res['pars'][5] *= fac
-        res["mom"] *= fac
-        res["mom_cov"] *= fac**2
-        res["mom_norm"] *= fac
         res["sums"] *= fac
         res["sums_cov"] *= fac**2
+        res["sums_norm"] *= fac
         res["wsum"] *= fac
-        res["mom_err"] *= fac
+        res["sums_err"] *= fac
         return res
 
     def _set_mompars(self):

--- a/ngmix/gmix/gmix.py
+++ b/ngmix/gmix/gmix.py
@@ -1244,16 +1244,8 @@ def get_weighted_moments_stats(ares):
         else:
             res[n] = ares[n]
 
-    scales = np.array([res["sums"][5]] * 5 + [1.0])
-    res["mom"] = res["sums"].copy()
-    res["mom"] /= scales
-    res["mom_cov"] = res["sums_cov"].copy()
-    for i in range(6):
-        for j in range(6):
-            res["mom_cov"][i, j] = res["mom_cov"][i, j]/scales[i]/scales[j]
-
     res.update(
-        moments.make_mom_result(res["mom"], res["mom_cov"])
+        moments.make_mom_result(res["sums"], res["sums_cov"], res["wsum"])
     )
 
     return res

--- a/ngmix/gmix/gmix.py
+++ b/ngmix/gmix/gmix.py
@@ -1245,7 +1245,7 @@ def get_weighted_moments_stats(ares):
             res[n] = ares[n]
 
     res.update(
-        moments.make_mom_result(res["sums"], res["sums_cov"], res["wsum"])
+        moments.make_mom_result(res["sums"].copy(), res["sums_cov"].copy(), res["wsum"])
     )
 
     return res

--- a/ngmix/gmix/gmix.py
+++ b/ngmix/gmix/gmix.py
@@ -1239,15 +1239,21 @@ def get_weighted_moments_stats(ares):
 
     res = {}
     for n in ares.dtype.names:
-        if n == "sums":
-            res[n] = ares[n].copy()
-        elif n == "sums_cov":
+        if n in ["sums", "sums_cov"]:
             res[n] = ares[n].copy()
         else:
             res[n] = ares[n]
 
+    scales = np.array([res["sums"][5]] * 5 + [1.0])
+    res["mom"] = res["sums"].copy()
+    res["mom"] /= scales
+    res["mom_cov"] = res["sums_cov"].copy()
+    for i in range(6):
+        for j in range(6):
+            res["mom_cov"][i, j] = res["mom_cov"][i, j]/scales[i]/scales[j]
+
     res.update(
-        moments.make_mom_result(res["sums"], res["sums_cov"])
+        moments.make_mom_result(res["mom"], res["mom_cov"])
     )
 
     return res

--- a/ngmix/moments.py
+++ b/ngmix/moments.py
@@ -349,7 +349,7 @@ def g2mom(g1, g2, T):
     return Irr, Irc, Icc
 
 
-def make_mom_result(mom, mom_cov):
+def make_mom_result(mom, mom_cov, mom_norm):
     """Make a fitting results dict from a set of moments.
 
     Parameters
@@ -358,6 +358,8 @@ def make_mom_result(mom, mom_cov):
         The array of moments in the order [Mv, Mu, M1, M2, MT, MF].
     mom_cov : np.ndarray
         The array of moment covariances.
+    mom_norm : float
+        The sum of the moment weight function itself.
 
     Returns
     -------
@@ -389,6 +391,7 @@ def make_mom_result(mom, mom_cov):
     res["flux"] = mom[mf_ind]
     res["mom"] = mom
     res["mom_cov"] = mom_cov
+    res["mom_norm"] = mom_norm
     res["flux_flags"] = 0
     res["flux_flagstr"] = ""
     res["T_flags"] = 0

--- a/ngmix/moments.py
+++ b/ngmix/moments.py
@@ -349,7 +349,7 @@ def g2mom(g1, g2, T):
     return Irr, Irc, Icc
 
 
-def make_mom_result(mom, mom_cov, mom_norm):
+def make_mom_result(mom, mom_cov, mom_norm=None):
     """Make a fitting results dict from a set of moments.
 
     Parameters
@@ -358,8 +358,9 @@ def make_mom_result(mom, mom_cov, mom_norm):
         The array of moments in the order [Mv, Mu, M1, M2, MT, MF].
     mom_cov : np.ndarray
         The array of moment covariances.
-    mom_norm : float
-        The sum of the moment weight function itself.
+    mom_norm : float, optional
+        The sum of the moment weight function itself. This is added to the output data.
+        The default of None puts in NaN.
 
     Returns
     -------
@@ -391,7 +392,7 @@ def make_mom_result(mom, mom_cov, mom_norm):
     res["flux"] = mom[mf_ind]
     res["mom"] = mom
     res["mom_cov"] = mom_cov
-    res["mom_norm"] = mom_norm
+    res["mom_norm"] = mom_norm if mom_norm is not None else np.nan
     res["flux_flags"] = 0
     res["flux_flagstr"] = ""
     res["T_flags"] = 0

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -581,7 +581,7 @@ def _ksigma_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
-        fk00=fkf[0, 0],
+        fk00=fkf[0],
     )
 
 
@@ -681,7 +681,7 @@ def _gauss_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
-        fk00=fkf[0, 0],
+        fk00=fkf[0],
     )
 
 

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -581,7 +581,7 @@ def _ksigma_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
-        fk00=fkf[0],
+        fk00=knrm,
     )
 
 
@@ -681,7 +681,7 @@ def _gauss_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
-        fk00=fkf[0],
+        fk00=knrm,
     )
 
 

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -164,7 +164,7 @@ class PrePSFMom(object):
             kim, kpsf_im, tot_var, eff_pad_factor, kernels,
             im_row - psf_im_row, im_col - psf_im_col,
         )
-        res = make_mom_result(mom, mom_cov, mom_norm)
+        res = make_mom_result(mom, mom_cov, mom_norm=mom_norm)
         if res['flags'] != 0:
             logger.debug("pre-psf moments failed: %s" % res['flagstr'])
 
@@ -291,7 +291,7 @@ def _measure_moments_fft(
     fkp = kernels["fkp"]
     fkc = kernels["fkc"]
 
-    mom_norm = np.sum(kernels["fk00"].real) * df2
+    mom_norm = kernels["fk00"]
     mf = np.sum((kim * fkf).real) * df2
     mr = np.sum((kim * fkr).real) * df2
     mp = np.sum((kim * fkp).real) * df2

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -164,7 +164,7 @@ class PrePSFMom(object):
             kim, kpsf_im, tot_var, eff_pad_factor, kernels,
             im_row - psf_im_row, im_col - psf_im_col,
         )
-        res = make_mom_result(mom, mom_cov, mom_norm=mom_norm)
+        res = make_mom_result(mom, mom_cov, sums_norm=mom_norm)
         if res['flags'] != 0:
             logger.debug("pre-psf moments failed: %s" % res['flagstr'])
 

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -160,11 +160,11 @@ class PrePSFMom(object):
         tot_var = np.sum(1.0 / obs.weight[msk])
 
         # run the actual measurements and return
-        mom, mom_cov = _measure_moments_fft(
+        mom, mom_cov, mom_norm = _measure_moments_fft(
             kim, kpsf_im, tot_var, eff_pad_factor, kernels,
             im_row - psf_im_row, im_col - psf_im_col,
         )
-        res = make_mom_result(mom, mom_cov)
+        res = make_mom_result(mom, mom_cov, mom_norm)
         if res['flags'] != 0:
             logger.debug("pre-psf moments failed: %s" % res['flagstr'])
 
@@ -291,6 +291,7 @@ def _measure_moments_fft(
     fkp = kernels["fkp"]
     fkc = kernels["fkc"]
 
+    mom_norm = np.sum(kernels["fk00"].real) * df2
     mf = np.sum((kim * fkf).real) * df2
     mr = np.sum((kim * fkr).real) * df2
     mp = np.sum((kim * fkp).real) * df2
@@ -324,7 +325,7 @@ def _measure_moments_fft(
 
     mom = np.array([np.nan, np.nan, mp, mc, mr, mf])
 
-    return mom, m_cov
+    return mom, m_cov, mom_norm
 
 
 @njit
@@ -580,6 +581,7 @@ def _ksigma_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
+        fk00=fkf[0, 0],
     )
 
 
@@ -679,6 +681,7 @@ def _gauss_kernels(
         fkc=fkc,
         msk=msk,
         nrm=nrm,
+        fk00=fkf[0, 0],
     )
 
 

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -371,8 +371,8 @@ def test_prepsfmom_gauss(
         _report_info("T", res["T"], T_true, np.mean(res["T_err"]))
         _report_info("g1", res["e"][:, 0], g1_true, np.mean(res["e_err"][0]))
         _report_info("g2", res["e"][:, 1], g2_true, np.mean(res["e_err"][1]))
-        mom_cov = np.cov(res["mom"].T)
-        print("mom cov ratio:\n", np.mean(res["mom_cov"], axis=0)/mom_cov, flush=True)
+        mom_cov = np.cov(res["sums"].T)
+        print("sums cov ratio:\n", np.mean(res["sums_cov"], axis=0)/mom_cov, flush=True)
         assert_allclose(
             np.abs(np.mean(res["flux"]) - flux_true)/np.mean(res["flux_err"]),
             0,
@@ -496,10 +496,10 @@ def test_prepsfmom_mn_cov_psf(
     _report_info("T", res["T"], T_true, np.mean(res["T_err"]))
     _report_info("g1", res["e"][:, 0], g1_true, np.mean(res["e_err"][0]))
     _report_info("g2", res["e"][:, 1], g2_true, np.mean(res["e_err"][1]))
-    mom_cov = np.cov(res["mom"].T)
-    print("mom cov ratio:\n", np.mean(res["mom_cov"], axis=0)/mom_cov, flush=True)
-    print("mom cov meas:\n", mom_cov, flush=True)
-    print("mom cov pred:\n", np.mean(res["mom_cov"], axis=0), flush=True)
+    mom_cov = np.cov(res["sums"].T)
+    print("sums cov ratio:\n", np.mean(res["sums_cov"], axis=0)/mom_cov, flush=True)
+    print("sums cov meas:\n", mom_cov, flush=True)
+    print("sums cov pred:\n", np.mean(res["sums_cov"], axis=0), flush=True)
 
     assert_allclose(np.mean(res["flux"]), flux_true, atol=0, rtol=1e-2)
     assert_allclose(np.mean(res["T"]), T_true, atol=0, rtol=1e-2)
@@ -515,14 +515,14 @@ def test_prepsfmom_mn_cov_psf(
 
     assert_allclose(
         mom_cov[2:, 2:],
-        np.mean(res["mom_cov"][:, 2:, 2:], axis=0),
+        np.mean(res["sums_cov"][:, 2:, 2:], axis=0),
         atol=2.5e-1,
         rtol=0,
     )
 
     assert_allclose(
         np.diagonal(mom_cov[2:, 2:]),
-        np.diagonal(np.mean(res["mom_cov"][:, 2:, 2:], axis=0)),
+        np.diagonal(np.mean(res["sums_cov"][:, 2:, 2:], axis=0)),
         atol=0,
         rtol=2e-2,
     )
@@ -722,10 +722,10 @@ def test_prepsfmom_mn_cov_nopsf(
     _report_info("T", res["T"], T_true, np.mean(res["T_err"]))
     _report_info("g1", res["e"][:, 0], g1_true, np.mean(res["e_err"][0]))
     _report_info("g2", res["e"][:, 1], g2_true, np.mean(res["e_err"][1]))
-    mom_cov = np.cov(res["mom"].T)
-    print("mom cov ratio:\n", np.mean(res["mom_cov"], axis=0)/mom_cov, flush=True)
-    print("mom cov meas:\n", mom_cov, flush=True)
-    print("mom cov pred:\n", np.mean(res["mom_cov"], axis=0), flush=True)
+    mom_cov = np.cov(res["sums"].T)
+    print("sums cov ratio:\n", np.mean(res["sums_cov"], axis=0)/mom_cov, flush=True)
+    print("sums cov meas:\n", mom_cov, flush=True)
+    print("sums cov pred:\n", np.mean(res["sums_cov"], axis=0), flush=True)
 
     assert_allclose(np.mean(res["flux"]), flux_true, atol=0, rtol=1e-2)
     assert_allclose(np.mean(res["T"]), T_true, atol=0, rtol=1e-2)
@@ -741,14 +741,14 @@ def test_prepsfmom_mn_cov_nopsf(
 
     assert_allclose(
         mom_cov[2:, 2:],
-        np.mean(res["mom_cov"][:, 2:, 2:], axis=0),
+        np.mean(res["sums_cov"][:, 2:, 2:], axis=0),
         atol=2.5e-1,
         rtol=0,
     )
 
     assert_allclose(
         np.diagonal(mom_cov[2:, 2:]),
-        np.diagonal(np.mean(res["mom_cov"][:, 2:, 2:], axis=0)),
+        np.diagonal(np.mean(res["sums_cov"][:, 2:, 2:], axis=0)),
         atol=0,
         rtol=2e-2,
     )
@@ -762,7 +762,7 @@ def test_moments_make_mom_result_flags():
     for i in range(2, 6):
         _mom_cov = mom_cov.copy()
         _mom_cov[i, i] = -1
-        res = make_mom_result(mom, _mom_cov, mom_norm=1)
+        res = make_mom_result(mom, _mom_cov, sums_norm=1)
         assert (res["flags"] & ngmix.flags.NONPOS_VAR) != 0
         assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_VAR] in res["flagstr"]
         if i == 5:
@@ -782,7 +782,7 @@ def test_moments_make_mom_result_flags():
     # neg flux
     _mom = mom.copy()
     _mom[5] = -1
-    res = make_mom_result(_mom, mom_cov, mom_norm=1)
+    res = make_mom_result(_mom, mom_cov, sums_norm=1)
     assert (res["flags"] & ngmix.flags.NONPOS_FLUX) != 0
     assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_FLUX] in res["flagstr"]
     assert res["flux_flags"] == 0
@@ -793,7 +793,7 @@ def test_moments_make_mom_result_flags():
     # neg T
     _mom = mom.copy()
     _mom[4] = -1
-    res = make_mom_result(_mom, mom_cov, mom_norm=1)
+    res = make_mom_result(_mom, mom_cov, sums_norm=1)
     assert (res["flags"] & ngmix.flags.NONPOS_SIZE) != 0
     assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_SIZE] in res["flagstr"]
     assert res["flux_flags"] == 0
@@ -806,7 +806,7 @@ def test_moments_make_mom_result_flags():
         _mom_cov = mom_cov.copy()
         _mom_cov[4, i] = np.nan
         _mom_cov[i, 4] = np.nan
-        res = make_mom_result(mom, _mom_cov, mom_norm=1)
+        res = make_mom_result(mom, _mom_cov, sums_norm=1)
         assert (res["flags"] & ngmix.flags.NONPOS_SHAPE_VAR) != 0
         assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_SHAPE_VAR] in res["flagstr"]
         assert res["flux_flags"] == 0
@@ -940,7 +940,7 @@ def test_prepsfmom_mom_norm(
     ).go(
         obs=obs, no_psf=True,
     )
-    assert_allclose(res["mom_norm"], res["flux"], atol=0, rtol=2e-4)
+    assert_allclose(res["sums_norm"], res["flux"], atol=0, rtol=2e-4)
 
 
 @pytest.mark.parametrize('pixel_scale', [0.25, 0.125])

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -762,7 +762,7 @@ def test_moments_make_mom_result_flags():
     for i in range(2, 6):
         _mom_cov = mom_cov.copy()
         _mom_cov[i, i] = -1
-        res = make_mom_result(mom, _mom_cov)
+        res = make_mom_result(mom, _mom_cov, 1)
         assert (res["flags"] & ngmix.flags.NONPOS_VAR) != 0
         assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_VAR] in res["flagstr"]
         if i == 5:
@@ -782,7 +782,7 @@ def test_moments_make_mom_result_flags():
     # neg flux
     _mom = mom.copy()
     _mom[5] = -1
-    res = make_mom_result(_mom, mom_cov)
+    res = make_mom_result(_mom, mom_cov, 1)
     assert (res["flags"] & ngmix.flags.NONPOS_FLUX) != 0
     assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_FLUX] in res["flagstr"]
     assert res["flux_flags"] == 0
@@ -793,7 +793,7 @@ def test_moments_make_mom_result_flags():
     # neg T
     _mom = mom.copy()
     _mom[4] = -1
-    res = make_mom_result(_mom, mom_cov)
+    res = make_mom_result(_mom, mom_cov, 1)
     assert (res["flags"] & ngmix.flags.NONPOS_SIZE) != 0
     assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_SIZE] in res["flagstr"]
     assert res["flux_flags"] == 0
@@ -806,7 +806,7 @@ def test_moments_make_mom_result_flags():
         _mom_cov = mom_cov.copy()
         _mom_cov[4, i] = np.nan
         _mom_cov[i, 4] = np.nan
-        res = make_mom_result(mom, _mom_cov)
+        res = make_mom_result(mom, _mom_cov, 1)
         assert (res["flags"] & ngmix.flags.NONPOS_SHAPE_VAR) != 0
         assert ngmix.flags.NAME_MAP[ngmix.flags.NONPOS_SHAPE_VAR] in res["flagstr"]
         assert res["flux_flags"] == 0


### PR DESCRIPTION
This PR adds the overall moment weight function normalization to fix a bug in mdet where this is ignored when combining shapes.

To do:

 - [x] tests