### PR TITLE
BUG use area norm for all gauss mom things

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## v2.1.0
 
+### bug fixes
+
+    - Fixed 1/area normalization for all moments fields in `GaussMom` results.
+
 ### new features
 
     - Added `fwhm_smooth` keyword to pre-PSF moments routines to allow for extra

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -58,6 +58,13 @@ class GaussMom(object):
         res['flux'] *= fac
         res['flux_err'] *= fac
         res['pars'][5] *= fac
+        res["mom"] *= fac
+        res["mom_cov"] *= fac**2
+        res["mom_norm"] *= fac
+        res["sums"] *= fac
+        res["sums_cov"] *= fac**2
+        res["wsum"] *= fac
+        res["mom_err"] *= fac
         return res
 
     def _set_mompars(self):


### PR DESCRIPTION
This PR changes GaussMom to use the 1/area normalization consistently everywhere in its outputs.