### PR TITLE
BUG non-scalar norm in sums_norm for prepsf moments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,15 +3,14 @@
 ### bug fixes
 
     - Fixed 1/area normalization for all moments fields in `GaussMom` results.
-### changes
 
-    - Changed "mom*" fields in the moments outputs to "sums*".
 ### new features
 
     - Added `fwhm_smooth` keyword to pre-PSF moments routines to allow for extra
       smoothing of the profile before the moments are measured.
     - Added caching of FFTs in metacal and pre-PSF moment rountines.
     - Added moments weight function normalization.
+    - Changed `mom*` fields in the moments outputs to `sums*`.
 
 
 ## v2.0.6

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -545,12 +545,6 @@ def _ksigma_kernels(
             "norm = %f (should be 1)!" % (kernel_size, nrm)
         )
 
-    # add smoothing after norm check above for kernel size
-    if fwhm_smooth > 0:
-        exp_val_smooth = _get_fwhm_smooth_profile(fwhm_smooth, fmag2)
-        fkf *= exp_val_smooth
-        knrm *= exp_val_smooth
-
     # the moment kernels take a bit more work
     # product by u^2 in real space is -dk^2/dku^2 in Fourier space
     # same holds for v and cross deriv is -dk^2/dkudkv
@@ -564,6 +558,13 @@ def _ksigma_kernels(
     # code is all that efficient anyways.
     two_knrm_dWdk2 = (-knrm * 8.0 / kmax2) * karg3
     four_knrm_dW2dk22 = (knrm * 48 / kmax2**2) * karg2
+
+    # add smoothing after norm check above for kernel size
+    if fwhm_smooth > 0:
+        exp_val_smooth = _get_fwhm_smooth_profile(fwhm_smooth, fmag2)
+        fkf *= exp_val_smooth
+        two_knrm_dWdk2 *= exp_val_smooth
+        four_knrm_dW2dk22 *= exp_val_smooth
 
     # the linear combinations here measure the moments proportional to the size
     # and shears - see the Mf, Mr, M+, Mx moments in Bernstein et al., arXiv:1508.05655
@@ -650,7 +651,6 @@ def _gauss_kernels(
     if fwhm_smooth > 0:
         exp_val_smooth = _get_fwhm_smooth_profile(fwhm_smooth, fmag2)
         fkf *= exp_val_smooth
-        knrm *= exp_val_smooth
 
     # the moment kernels take a bit more work
     # product by u^2 in real space is -dk^2/dku^2 in Fourier space

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -916,7 +916,7 @@ def test_prepsfmom_gauss_true_flux(
 @pytest.mark.parametrize('cls', [PGaussMom, KSigmaMom])
 @pytest.mark.parametrize('fwhm_smooth', [0, 1.5])
 def test_prepsfmom_mom_norm(
-    pad_factor, image_size, pixel_scale, mom_fwhm, cls,
+    pad_factor, image_size, pixel_scale, mom_fwhm, cls, fwhm_smooth,
 ):
     rng = np.random.RandomState(seed=100)
 

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -914,6 +914,7 @@ def test_prepsfmom_gauss_true_flux(
 @pytest.mark.parametrize('pad_factor', [3.5, 4])
 @pytest.mark.parametrize('mom_fwhm', [2, 2.5])
 @pytest.mark.parametrize('cls', [PGaussMom, KSigmaMom])
+@pytest.mark.parametrize('fwhm_smooth', [0, 1.5])
 def test_prepsfmom_mom_norm(
     pad_factor, image_size, pixel_scale, mom_fwhm, cls,
 ):
@@ -936,7 +937,7 @@ def test_prepsfmom_mom_norm(
         jacobian=jac,
     )
     res = cls(
-        fwhm=mom_fwhm, pad_factor=pad_factor,
+        fwhm=mom_fwhm, pad_factor=pad_factor, fwhm_smooth=fwhm_smooth,
     ).go(
         obs=obs, no_psf=True,
     )


### PR DESCRIPTION
I missed testing this branch of the code and it had a bug. 