### PR TITLE
ENH deconvolve pixel in prepsf moments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
    - Caching in pre-psf moments and metacal is now optional
      with an API to turn it on. Default is off.
+   - Pixel in pre-PSF moments is not deconvolved when doing PSFs.
 
 ## v2.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
     - Added moments weight function normalization.
     - Changed `mom*` fields in the moments outputs to `sums*`.
     - Added `sums_norm` field to adaptive moments outputs.
+    - The prePSF moments now deconvolve the pixel when running with no PSF.
 
 
 ## v2.0.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,6 @@
     - Added moments weight function normalization.
     - Changed `mom*` fields in the moments outputs to `sums*`.
     - Added `sums_norm` field to adaptive moments outputs.
-    - The prePSF moments now deconvolve the pixel when running with no PSF.
 
 
 ## v2.0.6

--- a/ngmix/prepsfmom.py
+++ b/ngmix/prepsfmom.py
@@ -106,12 +106,8 @@ class PrePSFMom(object):
                 0,  # we do not apodize PSF stamps since it should not be needed
             )
         else:
-            if False:
-                # delta function in real-space
-                kpsf_im = np.ones_like(kim, dtype=np.complex128)
-            else:
-                # pixel in real-space
-                kpsf_im = _pixel_fft(kim.shape[0])
+            # pixel in real-space
+            kpsf_im = _pixel_fft(kim.shape[0])
 
             psf_im_row = 0.0
             psf_im_col = 0.0

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -337,7 +337,7 @@ def test_prepsfmom_gauss(
         nx=image_size,
         ny=image_size,
         wcs=gs_wcs,
-        method='no_pixel').array
+    ).array
     obs = Observation(
         image=im_true,
         jacobian=jac,
@@ -463,7 +463,7 @@ def test_prepsfmom_mn_cov_psf(
         nx=image_size,
         ny=image_size,
         wcs=gs_wcs,
-        method='no_pixel').array
+    ).array
     obs = Observation(
         image=im_true,
         jacobian=jac,
@@ -599,7 +599,7 @@ def test_prepsfmom_fwhm_smooth_snr(
             nx=image_size,
             ny=image_size,
             wcs=gs_wcs,
-            method='no_pixel').array
+        ).array
         obs = Observation(
             image=im_true,
             jacobian=jac,
@@ -889,7 +889,7 @@ def test_prepsfmom_gauss_true_flux(
         nx=image_size,
         ny=image_size,
         wcs=gs_wcs,
-        method='no_pixel').array
+    ).array
     obs = Observation(
         image=im_true,
         jacobian=jac,
@@ -982,10 +982,22 @@ def test_prepsfmom_comp_to_gaussmom_simple(
         ny=image_size,
         wcs=gs_wcs,
     ).array
+    im_true_nopixel = gal.drawImage(
+        nx=image_size,
+        ny=image_size,
+        wcs=gs_wcs,
+        method="no_pixel",
+    ).array
+
     obs = Observation(
         image=im_true,
         jacobian=jac,
     )
+    obs_nopixel = Observation(
+        image=im_true_nopixel,
+        jacobian=jac,
+    )
+
     res = PGaussMom(
         fwhm=mom_fwhm, pad_factor=pad_factor,
     ).go(
@@ -993,14 +1005,14 @@ def test_prepsfmom_comp_to_gaussmom_simple(
     )
 
     from ngmix.gaussmom import GaussMom
-    res_gmom = GaussMom(fwhm=mom_fwhm).go(obs=obs)
+    res_gmom = GaussMom(fwhm=mom_fwhm).go(obs=obs_nopixel)
 
     for k in sorted(res):
         if k in res_gmom:
             print("%s:" % k, res[k], res_gmom[k])
 
     for k in ["flux", "flux_err", "T", "T_err", "e", "e_cov"]:
-        assert_allclose(res[k], res_gmom[k], atol=0, rtol=1e-2)
+        assert_allclose(res[k], res_gmom[k], atol=0, rtol=2.5e-2)
 
 
 @pytest.mark.parametrize('pixel_scale', [0.25, 0.125])
@@ -1060,9 +1072,16 @@ def test_prepsfmom_comp_to_gaussmom_fwhm_smooth(
             nx=image_size,
             ny=image_size,
             wcs=gs_wcs,
+            method="no_pixel",
         ).array
     else:
-        im_true_smooth = im_true
+        im_true_smooth = gal.drawImage(
+            nx=image_size,
+            ny=image_size,
+            wcs=gs_wcs,
+            method="no_pixel",
+        ).array
+
     obs_smooth = Observation(
         image=im_true_smooth,
         jacobian=jac,
@@ -1074,8 +1093,8 @@ def test_prepsfmom_comp_to_gaussmom_fwhm_smooth(
             print("%s:" % k, res[k], res_gmom[k])
 
     assert_allclose(res["flux"], res_gmom["flux"], atol=0, rtol=5e-4)
-    assert_allclose(res["T"], res_gmom["T"], atol=0, rtol=1e-3)
-    assert_allclose(res["e"], res_gmom["e"], atol=0, rtol=1e-3)
+    assert_allclose(res["T"], res_gmom["T"], atol=0, rtol=2e-3)
+    assert_allclose(res["e"], res_gmom["e"], atol=0, rtol=3e-3)
     # the errors do not match - this is because the underlying noise model is
     # different - the pure gaussian moments weight map is an error on the convolved
     # profile whereas the pre-PSF case uses error propagation through the

--- a/ngmix/tests/test_prepsfmom.py
+++ b/ngmix/tests/test_prepsfmom.py
@@ -1178,8 +1178,33 @@ def _sim_apodize(flux_factor, ap_rad):
     ap_mask = np.ones_like(im)
     if ap_rad > 0:
         _build_square_apodization_mask(ap_rad, ap_mask)
+
+    # get true flux
+    im_nopixel = gal.drawImage(
+        nx=image_size,
+        ny=image_size,
+        wcs=gs_wcs,
+        method="no_pixel",
+    ).array
+
+    im_nopixel += galsim.Exponential(
+        half_light_radius=fwhm
+    ).shear(
+        g1=-0.5, g2=0.2
+    ).shift(
+        cen*pixel_scale,
+        0,
+    ).withFlux(
+        400*flux_factor
+    ).drawImage(
+        nx=image_size,
+        ny=image_size,
+        wcs=gs_wcs,
+        method="no_pixel",
+    ).array
+
     obs_ap = Observation(
-        image=im * ap_mask,
+        image=im_nopixel * ap_mask,
         jacobian=jac,
     )
 


### PR DESCRIPTION
This PR adds a pixel deconvolution for PSFs only when running prePSF moments. This feature makes the PSF moments consistent with object ones in that the pixel is removed.