### PR TITLE
Add optional higher order moments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 ## New features
 
     - Added optional calculation of higher order moments when calling
-        gmix.get_weighted_moments(obs, higher=True)
-      This is also available with GaussMom(fwhm, higher=True)
+        gmix.get_weighted_moments(obs, with_higher_order=True)
+      This is also available with GaussMom(fwhm, with_higher_order=True)
 
       Currently the sums are calculated and are stored in a larger "sums" and
       "sums_cov" arrays in the results.  No normalized moments are returned.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 ## v2.3.2 (not yet released)
 
+
+## New features
+
+    - Added optional calculation of higher order moments when calling
+        gmix.get_weighted_moments(obs, higher=True)
+      This is also available with GaussMom(fwhm, higher=True)
+
+      Currently the sums are calculated and are stored in a larger "sums" and
+      "sums_cov" arrays in the results.  No normalized moments are returned.
+
+      Names and indices for moments can be found in moments.MOMENTS_NAME_MAP
+
 ## Bug Fixes
 
     - Fixed bug when moments are used in guesser and size is bad.

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -12,12 +12,17 @@ class GaussMom(object):
     ----------
     fwhm: float
         The FWHM of the Gaussian weight function.
+    higher: bool, optional
+        If set to True, return higher order moments in the sums/sums_cov
+        arrays.  See ngmix.moments.MOMENTS_NAME_MAP for a map between
+        name and index.
     """
 
     kind = "wmom"
 
-    def __init__(self, fwhm):
+    def __init__(self, fwhm, higher=False):
         self.fwhm = fwhm
+        self.higher = higher
         self._set_mompars()
 
     def go(self, obs):
@@ -46,7 +51,9 @@ class GaussMom(object):
         measure weighted moments
         """
 
-        res = self.weight.get_weighted_moments(obs=obs, maxrad=1.e9)
+        res = self.weight.get_weighted_moments(
+            obs=obs, maxrad=1.e9, higher=self.higher,
+        )
 
         if res['flags'] != 0:
             return res

--- a/ngmix/gaussmom.py
+++ b/ngmix/gaussmom.py
@@ -12,7 +12,7 @@ class GaussMom(object):
     ----------
     fwhm: float
         The FWHM of the Gaussian weight function.
-    higher: bool, optional
+    with_higher_order: bool, optional
         If set to True, return higher order moments in the sums/sums_cov
         arrays.  See ngmix.moments.MOMENTS_NAME_MAP for a map between
         name and index.
@@ -20,9 +20,9 @@ class GaussMom(object):
 
     kind = "wmom"
 
-    def __init__(self, fwhm, higher=False):
+    def __init__(self, fwhm, with_higher_order=False):
         self.fwhm = fwhm
-        self.higher = higher
+        self.with_higher_order = with_higher_order
         self._set_mompars()
 
     def go(self, obs):
@@ -52,7 +52,7 @@ class GaussMom(object):
         """
 
         res = self.weight.get_weighted_moments(
-            obs=obs, maxrad=1.e9, higher=self.higher,
+            obs=obs, with_higher_order=self.with_higher_order,
         )
 
         if res['flags'] != 0:

--- a/ngmix/gmix/gmix.py
+++ b/ngmix/gmix/gmix.py
@@ -638,7 +638,7 @@ class GMix(object):
             gm, obs._pixels, fdiff, start,
         )
 
-    def get_weighted_moments(self, obs, maxrad=None, higher=False):
+    def get_weighted_moments(self, obs, maxrad=None, with_higher_order=False):
         """
         Get weighted moments using this mixture as the weight, including
         e1,e2,T,s2n etc.  If you just want the raw moments use
@@ -654,7 +654,7 @@ class GMix(object):
             The Observation must have a weight map set
         maxrad: float, optional
             If sent, limit moments to within the specified maximum radius
-        higher: bool, optional
+        with_higher_order: bool, optional
             If set to True, return higher order moments in the sums/sums_cov
             arrays.  See ngmix.moments.MOMENTS_NAME_MAP for a map between
             name and index.
@@ -665,10 +665,12 @@ class GMix(object):
         such as e1,e2,T,s2n etc.
         """
 
-        res = self.get_weighted_sums(obs, maxrad=maxrad, higher=higher)
+        res = self.get_weighted_sums(
+            obs, maxrad=maxrad, with_higher_order=with_higher_order,
+        )
         return get_weighted_moments_stats(res)
 
-    def get_weighted_sums(self, obs, maxrad=None, higher=False, res=None):
+    def get_weighted_sums(self, obs, maxrad=None, with_higher_order=False, res=None):
         """
         Get weighted moments using this mixture as the weight.  To
         get more summary statistics use get_weighted_moments or
@@ -681,7 +683,7 @@ class GMix(object):
             The Observation must have a weight map set
         maxrad: float, optional
             If sent, limit moments to within the specified maximum radius
-        higher: bool, optional
+        with_higher_order: bool, optional
             If set to True, return higher order moments in the sums/sums_cov
             arrays.  See ngmix.moments.MOMENTS_NAME_MAP for a map between
             name and index.
@@ -701,7 +703,7 @@ class GMix(object):
             maxrad = np.inf
 
         if res is None:
-            dt0 = get_moments_result_dtype(higher=higher)
+            dt0 = get_moments_result_dtype(with_higher_order=with_higher_order)
             dt = np.dtype(dt0, align=True)
             resarray = np.zeros(1, dtype=dt)
             res = resarray[0]
@@ -709,8 +711,8 @@ class GMix(object):
         wt_gm = self.get_data()
 
         # this will add to the sums
-        if higher:
-            gmix_nb.get_higher_weighted_sums(wt_gm, obs.pixels, res, maxrad)
+        if with_higher_order:
+            gmix_nb.get_higher_order_weighted_sums(wt_gm, obs.pixels, res, maxrad)
         else:
             gmix_nb.get_weighted_sums(wt_gm, obs.pixels, res, maxrad)
 
@@ -1274,8 +1276,8 @@ def get_weighted_moments_stats(ares):
     return res
 
 
-def get_moments_result_dtype(higher=False):
-    if higher:
+def get_moments_result_dtype(with_higher_order=False):
+    if with_higher_order:
         nmom = 17
     else:
         nmom = 6

--- a/ngmix/gmix/gmix.py
+++ b/ngmix/gmix/gmix.py
@@ -700,7 +700,9 @@ class GMix(object):
         self.set_norms_if_needed()
 
         if maxrad is None:
-            maxrad = np.inf
+            T = self.get_T()
+            sigma = np.sqrt(T/2)
+            maxrad = 100 * sigma
 
         if res is None:
             dt0 = get_moments_result_dtype(with_higher_order=with_higher_order)

--- a/ngmix/gmix/gmix_nb.py
+++ b/ngmix/gmix/gmix_nb.py
@@ -726,7 +726,7 @@ def get_weighted_sums(wt, pixels, res, maxrad):
 
 
 @njit
-def get_higher_weighted_sums(wt, pixels, res, maxrad):
+def get_higher_order_weighted_sums(wt, pixels, res, maxrad):
     """
     Do sums for calculating the weighted moments.
 

--- a/ngmix/gmix/gmix_nb.py
+++ b/ngmix/gmix/gmix_nb.py
@@ -787,31 +787,20 @@ def get_higher_weighted_sums(wt, pixels, res, maxrad):
             F[5] = 1.0
 
             # third
-            # M_{21} &= \sum W(u,v) I(u,v) du (du^2 + dv^2)
             F[6] = u * r2
-            # M_{12} &= \sum W(u,v) I(u,v) dv (du^2 + dv^2)
             F[7] = v * r2
-            # M_{30} &= \sum W(u,v) I(u,v) du (du^2 - 3 dv^2)
             F[8] = u * (u2 - 3 * v2)
-            # M_{03} &= \sum W(u,v) I(u,v) dv (3 du^2 - dv^2)
             F[9] = v * (3 * u2 - v2)
 
             # fourth
-            # M_{22} &= \sum W(u,v) I(u,v) (du^2 + dv^2)^2
             F[10] = r4
-            # M_{31} &= \sum W(u,v) I(u,v) (du^2 + dv^2) (du^2 - dv^2)
             F[11] = r2 * (u2 - v2)
-            # M_{13} &= \sum W(u,v) I(u,v) (du^2 + dv^2) (2 du dv)
             F[12] = r2 * 2 * u * v
-            # M_{40} &= \sum W(u,v) I(u,v) (du^4 - 6 du^2 dv^2 + dv^4)
             F[13] = u4 - 6 * u2 * v2 + v4
-            # M_{04} &= \sum W(u,v) I(u,v) (du^2 - dv^2) (4 du dv)
             F[14] = (u2 - v2) * 4 * u * v
 
-            # pure radial momentes 6, 8
-            # M_{33} &= \sum W(u,v) I(u,v) r^6
+            # Additional pure radial momentes 6, 8
             F[15] = r6
-            # M_{44} &= \sum W(u,v) I(u,v) r^8
             F[16] = r8
 
             res["wsum"] += weight

--- a/ngmix/moments.py
+++ b/ngmix/moments.py
@@ -22,6 +22,14 @@ MOMENTS_NAME_MAP = {
     # notation from piff.util.calculate_moments
     # third order
 
+    # these are same as above but with the alternative notation
+    "M00": 5,  # same as MF
+    "M10": 1,  # same as Mu
+    "M01": 0,  # same as Mv
+    "M11": 4,  # same as MT
+    "M20": 2,  # same as M1
+    "M02": 3,  # same as M2
+
     # u * r^2
     "M21": 6,
     # v * r^2

--- a/ngmix/moments.py
+++ b/ngmix/moments.py
@@ -6,12 +6,50 @@ import ngmix.flags
 from .util import get_ratio_error
 
 MOMENTS_NAME_MAP = {
+    # v
     "Mv": 0,
+    # u
     "Mu": 1,
+    # u^2 - v^2
     "M1": 2,
+    # v * u
     "M2": 3,
+    # v^2 + u^2
     "MT": 4,
+    # 1 (flux)
     "MF": 5,
+
+    # notation from piff.util.calculate_moments
+    # third order
+
+    # u * r^2
+    "M21": 6,
+    # v * r^2
+    "M12": 7,
+    # u * (u^2 - 3 * v^2)
+    "M30": 8,
+    # v * (3 * u^2 - v^2)
+    "M03": 9,
+
+    # fourth order
+    # r^4
+    "M22": 10,
+    # r^2 * (u^ - v^)
+    "M31": 11,
+    # r^2 * 2 * u * v
+    "M13": 12,
+    # u^4 - 6 * u^2 * v^2 + v^4
+    "M40": 13,
+    # (u^2 - v^2) * 4 * u * v
+    "M14": 14,
+
+    # 6th order
+    # r^6
+    "M33": 15,
+
+    # 8th order
+    # r^8
+    "M44": 16,
 }
 
 
@@ -368,14 +406,14 @@ def make_mom_result(sums, sums_cov, sums_norm=None):
         A dictionary of results.
     """
     # for safety...
-    if len(sums) != 6:
+    if len(sums) != 6 and len(sums) != 17:
         raise ValueError(
-            "You must pass exactly 6 unnormalized moments in the order "
-            "[Mv, Mu, M1, M2, MT, MF] for ngmix.moments.make_mom_result."
+            "You must pass exactly 6 or 17 unnormalized moments in the order "
+            "[Mv, Mu, M1, M2, MT, MF, ...] for ngmix.moments.make_mom_result."
         )
-    if sums_cov.shape != (6, 6):
+    if sums_cov.shape != (6, 6) and sums_cov.shape != (17, 17):
         raise ValueError(
-            "You must pass a 6x6 matrix for ngmix.moments.make_mom_result."
+            "You must pass a 6x6 or 17x17 matrix for ngmix.moments.make_mom_result."
         )
 
     mv_ind = MOMENTS_NAME_MAP["Mv"]

--- a/ngmix/tests/test_gaussmom.py
+++ b/ngmix/tests/test_gaussmom.py
@@ -128,7 +128,7 @@ def test_gaussmom_higher_smoke(do_higher):
     jacobian = ngmix.DiagonalJacobian(row=cen[0], col=cen[1], scale=scale)
     obs = Observation(image=im, jacobian=jacobian)
 
-    fitter = GaussMom(fwhm=1.2, higher=do_higher)
+    fitter = GaussMom(fwhm=1.2, with_higher_order=do_higher)
 
     res = fitter.go(obs)
     if do_higher:
@@ -170,7 +170,7 @@ def test_gaussmom_higher_order():
 
         obs = Observation(image=im, jacobian=jacobian)
 
-        fitter = GaussMom(fwhm=fwhm, higher=True)
+        fitter = GaussMom(fwhm=fwhm, with_higher_order=True)
 
         res = fitter.go(obs)
 

--- a/ngmix/tests/test_gaussmom.py
+++ b/ngmix/tests/test_gaussmom.py
@@ -6,7 +6,7 @@ import ngmix
 from ngmix import Jacobian
 from ngmix.gaussmom import GaussMom
 from ngmix import Observation
-from ngmix.moments import fwhm_to_T
+from ngmix.moments import fwhm_to_T, MOMENTS_NAME_MAP, fwhm_to_sigma
 from ngmix.shape import e1e2_to_g1g2
 
 
@@ -112,6 +112,76 @@ def test_gaussmom_smoke(g1_true, g2_true, wcs_g1, wcs_g2, weight_fac):
     if weight_fac > 1:
         assert np.allclose(flux_true, np.sum(im))
     assert np.abs(np.mean(farr) - flux_true) < 1e-4, (np.mean(farr), np.std(farr))
+
+
+@pytest.mark.parametrize('do_higher', [False, True])
+def test_gaussmom_higher_smoke(do_higher):
+    fwhm = 0.9
+    scale = 0.263
+
+    obj = galsim.Gaussian(fwhm=fwhm)
+    im = obj.drawImage(
+        scale=scale,
+    ).array
+
+    cen = (np.array(im.shape) - 1) / 2
+    jacobian = ngmix.DiagonalJacobian(row=cen[0], col=cen[1], scale=scale)
+    obs = Observation(image=im, jacobian=jacobian)
+
+    fitter = GaussMom(fwhm=1.2, higher=do_higher)
+
+    res = fitter.go(obs)
+    if do_higher:
+        assert res['sums'].shape == (17, )
+        assert res['sums_cov'].shape == (17, 17)
+    else:
+        assert res['sums'].shape == (6, )
+        assert res['sums_cov'].shape == (6, 6)
+
+
+def test_gaussmom_higher_order():
+    rng = np.random.RandomState(seed=35)
+    fwhm = 0.9
+    sigma = fwhm_to_sigma(fwhm)
+    scale = 0.125
+    image_size = 107
+
+    ntrial = 100
+
+    rho4s = np.zeros(ntrial)
+    for i in range(ntrial):
+        obj = galsim.Gaussian(fwhm=fwhm)
+
+        row_offset, col_offset = rng.uniform(low=-0.5, high=0.5, size=2)
+
+        im = obj.drawImage(
+            nx=image_size,
+            ny=image_size,
+            offset=(col_offset, row_offset),
+            scale=scale,
+            method='no_pixel',
+        ).array
+
+        imcen = (np.array(im.shape) - 1) / 2
+
+        cen = imcen + (row_offset, col_offset)
+
+        jacobian = ngmix.DiagonalJacobian(row=cen[0], col=cen[1], scale=scale)
+
+        obs = Observation(image=im, jacobian=jacobian)
+
+        fitter = GaussMom(fwhm=fwhm, higher=True)
+
+        res = fitter.go(obs)
+
+        f_ind = MOMENTS_NAME_MAP["MF"]
+        M22_ind = MOMENTS_NAME_MAP["M22"]
+        rho4s[i] = res['sums'][M22_ind] / res['sums'][f_ind] / sigma**4
+
+    rho4_mean = rho4s.mean()
+    rho4_std = rho4s.std()
+    print(f'rho4: {rho4_mean:.3g} std: {rho4_std:.3g}')
+    assert np.abs(rho4_mean - 2) < 1e-5
 
 
 def test_gaussmom_flags():

--- a/ngmix/tests/test_gmix.py
+++ b/ngmix/tests/test_gmix.py
@@ -509,7 +509,7 @@ def test_higher_order_smoke(do_higher):
         model='gauss',
     )
 
-    res = wt.get_weighted_moments(obs, higher=do_higher)
+    res = wt.get_weighted_moments(obs, with_higher_order=do_higher)
     if do_higher:
         assert res['sums'].shape == (17, )
         assert res['sums_cov'].shape == (17, 17)
@@ -566,7 +566,7 @@ def test_higher_order():
             model='gauss',
         )
 
-        res = wt.get_weighted_moments(obs, higher=True)
+        res = wt.get_weighted_moments(obs, with_higher_order=True)
 
         f_ind = MOMENTS_NAME_MAP["MF"]
         M22_ind = MOMENTS_NAME_MAP["M22"]

--- a/ngmix/tests/test_gmix.py
+++ b/ngmix/tests/test_gmix.py
@@ -542,6 +542,18 @@ def test_higher_order():
     rho4s = np.zeros(ntrial)
     rho6s = np.zeros(ntrial)
     rho8s = np.zeros(ntrial)
+
+    rho_M21 = np.zeros(ntrial)
+    rho_M12 = np.zeros(ntrial)
+    rho_M30 = np.zeros(ntrial)
+    rho_M03 = np.zeros(ntrial)
+
+    rho_M31 = np.zeros(ntrial)
+    rho_M13 = np.zeros(ntrial)
+
+    rho_M40 = np.zeros(ntrial)
+    rho_M14 = np.zeros(ntrial)
+
     for i in range(ntrial):
         obj = galsim.Gaussian(fwhm=fwhm)
 
@@ -581,6 +593,30 @@ def test_higher_order():
         M44_ind = MOMENTS_NAME_MAP["M44"]
         rho8s[i] = res['sums'][M44_ind] / res['sums'][f_ind] / sigma**8
 
+        M21_ind = MOMENTS_NAME_MAP["M21"]
+        rho_M21[i] = res['sums'][M21_ind] / res['sums'][f_ind] / sigma**3
+
+        M12_ind = MOMENTS_NAME_MAP["M12"]
+        rho_M12[i] = res['sums'][M12_ind] / res['sums'][f_ind] / sigma**3
+
+        M30_ind = MOMENTS_NAME_MAP["M30"]
+        rho_M30[i] = res['sums'][M30_ind] / res['sums'][f_ind] / sigma**3
+
+        M03_ind = MOMENTS_NAME_MAP["M03"]
+        rho_M03[i] = res['sums'][M03_ind] / res['sums'][f_ind] / sigma**3
+
+        M31_ind = MOMENTS_NAME_MAP["M31"]
+        rho_M31[i] = res['sums'][M31_ind] / res['sums'][f_ind] / sigma**3
+
+        M13_ind = MOMENTS_NAME_MAP["M13"]
+        rho_M13[i] = res['sums'][M13_ind] / res['sums'][f_ind] / sigma**3
+
+        M40_ind = MOMENTS_NAME_MAP["M40"]
+        rho_M40[i] = res['sums'][M40_ind] / res['sums'][f_ind] / sigma**3
+
+        M14_ind = MOMENTS_NAME_MAP["M14"]
+        rho_M14[i] = res['sums'][M14_ind] / res['sums'][f_ind] / sigma**3
+
     rho4_mean = rho4s.mean()
     rho4_std = rho4s.std()
     print(f'rho4: {rho4_mean:.3g} std: {rho4_std:.3g}')
@@ -595,3 +631,27 @@ def test_higher_order():
     rho8_std = rho8s.std()
     print(f'rho8: {rho8_mean:.3g} std: {rho8_std:.3g}')
     assert np.abs(rho8_mean - 24) < 1e-5
+
+    rho_M21_mean = rho_M21.mean()
+    assert np.abs(rho_M21_mean) < 1e-5
+
+    rho_M12_mean = rho_M12.mean()
+    assert np.abs(rho_M12_mean) < 1e-5
+
+    rho_M30_mean = rho_M30.mean()
+    assert np.abs(rho_M30_mean) < 1e-5
+
+    rho_M03_mean = rho_M03.mean()
+    assert np.abs(rho_M03_mean) < 1e-5
+
+    rho_M31_mean = rho_M31.mean()
+    assert np.abs(rho_M31_mean) < 1e-5
+
+    rho_M13_mean = rho_M13.mean()
+    assert np.abs(rho_M13_mean) < 1e-5
+
+    rho_M40_mean = rho_M40.mean()
+    assert np.abs(rho_M40_mean) < 1e-5
+
+    rho_M14_mean = rho_M14.mean()
+    assert np.abs(rho_M14_mean) < 1e-5

--- a/ngmix/tests/test_gmix.py
+++ b/ngmix/tests/test_gmix.py
@@ -606,16 +606,16 @@ def test_higher_order():
         rho_M03[i] = res['sums'][M03_ind] / res['sums'][f_ind] / sigma**3
 
         M31_ind = MOMENTS_NAME_MAP["M31"]
-        rho_M31[i] = res['sums'][M31_ind] / res['sums'][f_ind] / sigma**3
+        rho_M31[i] = res['sums'][M31_ind] / res['sums'][f_ind] / sigma**4
 
         M13_ind = MOMENTS_NAME_MAP["M13"]
-        rho_M13[i] = res['sums'][M13_ind] / res['sums'][f_ind] / sigma**3
+        rho_M13[i] = res['sums'][M13_ind] / res['sums'][f_ind] / sigma**4
 
         M40_ind = MOMENTS_NAME_MAP["M40"]
-        rho_M40[i] = res['sums'][M40_ind] / res['sums'][f_ind] / sigma**3
+        rho_M40[i] = res['sums'][M40_ind] / res['sums'][f_ind] / sigma**4
 
         M14_ind = MOMENTS_NAME_MAP["M14"]
-        rho_M14[i] = res['sums'][M14_ind] / res['sums'][f_ind] / sigma**3
+        rho_M14[i] = res['sums'][M14_ind] / res['sums'][f_ind] / sigma**4
 
     rho4_mean = rho4s.mean()
     rho4_std = rho4s.std()

--- a/ngmix/tests/test_gmix.py
+++ b/ngmix/tests/test_gmix.py
@@ -9,6 +9,7 @@ from ngmix.gmix import make_gmix_model
 from ngmix.shape import g1g2_to_e1e2
 from ngmix.shape import Shape
 import ngmix.moments
+from ngmix.moments import MOMENTS_NAME_MAP
 from ngmix import DiagonalJacobian, Observation
 
 
@@ -512,6 +513,17 @@ def test_higher_order_smoke(do_higher):
     if do_higher:
         assert res['sums'].shape == (17, )
         assert res['sums_cov'].shape == (17, 17)
+
+        assert MOMENTS_NAME_MAP['M00'] == MOMENTS_NAME_MAP['MF']
+        assert MOMENTS_NAME_MAP['M10'] == MOMENTS_NAME_MAP['Mu']
+        assert MOMENTS_NAME_MAP['M01'] == MOMENTS_NAME_MAP['Mv']
+        assert MOMENTS_NAME_MAP['M11'] == MOMENTS_NAME_MAP['MT']
+        assert MOMENTS_NAME_MAP['M20'] == MOMENTS_NAME_MAP['M1']
+        assert MOMENTS_NAME_MAP['M02'] == MOMENTS_NAME_MAP['M2']
+
+        for name, ind in MOMENTS_NAME_MAP.items():
+            # make sure the index is valid
+            res['sums'][ind]
     else:
         assert res['sums'].shape == (6, )
         assert res['sums_cov'].shape == (6, 6)
@@ -556,8 +568,8 @@ def test_higher_order():
 
         res = wt.get_weighted_moments(obs, higher=True)
 
-        f_ind = ngmix.moments.MOMENTS_NAME_MAP["MF"]
-        M22_ind = ngmix.moments.MOMENTS_NAME_MAP["M22"]
+        f_ind = MOMENTS_NAME_MAP["MF"]
+        M22_ind = MOMENTS_NAME_MAP["M22"]
         rho4s[i] = res['sums'][M22_ind] / res['sums'][f_ind] / sigma**4
 
     rho4_mean = rho4s.mean()

--- a/ngmix/tests/test_gmix.py
+++ b/ngmix/tests/test_gmix.py
@@ -540,6 +540,8 @@ def test_higher_order():
     ntrial = 100
 
     rho4s = np.zeros(ntrial)
+    rho6s = np.zeros(ntrial)
+    rho8s = np.zeros(ntrial)
     for i in range(ntrial):
         obj = galsim.Gaussian(fwhm=fwhm)
 
@@ -569,10 +571,27 @@ def test_higher_order():
         res = wt.get_weighted_moments(obs, with_higher_order=True)
 
         f_ind = MOMENTS_NAME_MAP["MF"]
+
         M22_ind = MOMENTS_NAME_MAP["M22"]
         rho4s[i] = res['sums'][M22_ind] / res['sums'][f_ind] / sigma**4
+
+        M33_ind = MOMENTS_NAME_MAP["M33"]
+        rho6s[i] = res['sums'][M33_ind] / res['sums'][f_ind] / sigma**6
+
+        M44_ind = MOMENTS_NAME_MAP["M44"]
+        rho8s[i] = res['sums'][M44_ind] / res['sums'][f_ind] / sigma**8
 
     rho4_mean = rho4s.mean()
     rho4_std = rho4s.std()
     print(f'rho4: {rho4_mean:.3g} std: {rho4_std:.3g}')
     assert np.abs(rho4_mean - 2) < 1e-5
+
+    rho6_mean = rho6s.mean()
+    rho6_std = rho6s.std()
+    print(f'rho6: {rho6_mean:.3g} std: {rho6_std:.3g}')
+    assert np.abs(rho6_mean - 6) < 1e-5
+
+    rho8_mean = rho8s.mean()
+    rho8_std = rho8s.std()
+    print(f'rho8: {rho8_mean:.3g} std: {rho8_std:.3g}')
+    assert np.abs(rho8_mean - 24) < 1e-5


### PR DESCRIPTION
These are part of the sums/sums_cov arrays returned by gmix.get_weighted_moments when `with_higher_order=True` is sent.

This is also available with `GaussMom(fwhm, with_higher_order=True)`

Currently the sums are calculated and are stored in a larger "sums" and "sums_cov" arrays in the results.  No normalized moments are returned.

Names and indices for moments can be found in moments.MOMENTS_NAME_MAP