### PR TITLE
Compatibility with numpy 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     name: tests
     strategy:
       matrix:
-        pyver: ["3.9", "3.10", "3.11"]
+        pyver: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: "ubuntu-latest"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## v2.4.0
+
+### Compatibility
+
+    - Update to use either numpy>2. or 1.x
+
+ ### Misc
+
+    - Raise an exception if negative integers are passed to ``get_flags_str``.
+
 ## v2.3.2
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ngmix
 =====
 
-[![Build Status](https://travis-ci.com/esheldon/ngmix.svg?branch=master)](https://travis-ci.com/esheldon/ngmix)
+[![Build Status](https://github.com/esheldon/ngmix/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/esheldon/ngmix/actions/workflows/test.yml)
 
 Gaussian mixture models and other tools for working with 2d images, implemented
 in python. The code is made fast using the numba package.

--- a/ngmix/defaults.py
+++ b/ngmix/defaults.py
@@ -1,5 +1,10 @@
 import numpy as np
 
+# Shim to support numpy >= 2 and < 2.0.0.
+if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+    copy_if_needed = None
+else:
+    copy_if_needed = False
 
 # default values
 PDEF = -9.999e9  # parameter defaults

--- a/ngmix/fitting/galsim_results.py
+++ b/ngmix/fitting/galsim_results.py
@@ -5,7 +5,7 @@ __all__ = [
 import numpy as np
 from .results import FitModel, PSFFluxFitModel
 from ..gexceptions import GMixRangeError
-from ..defaults import LOWVAL
+from ..defaults import copy_if_needed, LOWVAL
 from .. import observation
 from ..observation import Observation, ObsList, MultiBandObsList
 
@@ -269,7 +269,7 @@ class GalsimFitModel(FitModel):
         exception
         """
 
-        guess = np.array(guess, dtype="f8", copy=False)
+        guess = np.array(guess, dtype="f8", copy=copy_if_needed)
         if guess.size != self.npars:
             raise ValueError(
                 "expected %d entries in the "

--- a/ngmix/fitting/results.py
+++ b/ngmix/fitting/results.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 from .. import gmix
 from ..gexceptions import GMixRangeError
-from ..defaults import PDEF, CDEF, LOWVAL, BIGVAL
+from ..defaults import PDEF, CDEF, LOWVAL, BIGVAL, copy_if_needed
 from ..observation import Observation, ObsList, get_mb_obs
 from ..gmix.gmix_nb import gmix_convolve_fill, fill_fdiff
 from ..gmix import GMixList, MultiBandGMixList
@@ -361,7 +361,7 @@ class FitModel(dict):
         setup the mixtures based on the initial guess
         """
 
-        guess = np.array(guess, dtype="f8", copy=False)
+        guess = np.array(guess, dtype="f8", copy=copy_if_needed)
 
         npars = guess.size
         mess = "guess has npars=%d, expected %d" % (npars, self.npars)

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -81,7 +81,7 @@ def get_flags_str(val, name_map=None):
     if val < 0:
         raise ValueError(f"Flag value {val} must be non-negative.")
 
-    # Cast to uint64 to ensure to allow for maximal flexibility.
+    # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
     val = np.array(val, dtype=np.uint32)

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -63,7 +63,7 @@ def get_flags_str(val, name_map=None):
     Parameters
     ----------
     val : int
-        The flag value.
+        The flag value. This must be in the range [0, 2**32).
     name_map : dict, optional
         A dictionary mapping values to names. Default is global at
         ngmix.flags.NAME_MAP.

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -63,7 +63,7 @@ def get_flags_str(val, name_map=None):
     Parameters
     ----------
     val : int
-        The flag value. This must be in the range [0, 2**32).
+        The flag value. This must be non-negative.
     name_map : dict, optional
         A dictionary mapping values to names. Default is global at
         ngmix.flags.NAME_MAP.
@@ -76,14 +76,20 @@ def get_flags_str(val, name_map=None):
     if name_map is None:
         name_map = NAME_MAP
 
-    if val < 0 or val >= 2**32:
-        import warnings
-        warnings.warn(f"Flag value {val} is out of range [0, 2**32).")
+    # Negative values are always invalid and cause confusion if cast to an
+    # unsigned integer.
+    if val < 0:
+        raise ValueError(f"Flag value {val} must be non-negative.")
+
+    # Cast to uint64 to ensure to allow for maximal flexibility.
+    # This is because the second argument to the bitwise AND operator (&) below
+    # would get implicitly cast to the same type as `val`.
+    val = np.array(val, dtype=np.uint64)
 
     nstrs = []
     for pow in range(31):
         fval = 2**pow
-        if ((np.array(val).astype(np.uint32) & fval) != 0):
+        if ((val & fval) != 0):
             if fval in name_map:
                 nstrs.append(name_map[fval])
             else:

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 NO_ATTEMPT = 2**0
 CEN_SHIFT = 2**1
 NONPOS_FLUX = 2**2
@@ -77,7 +79,7 @@ def get_flags_str(val, name_map=None):
     nstrs = []
     for pow in range(32):
         fval = 2**pow
-        if ((val & fval) != 0):
+        if ((np.uint32(val) & fval) != 0):
             if fval in name_map:
                 nstrs.append(name_map[fval])
             else:

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -84,7 +84,7 @@ def get_flags_str(val, name_map=None):
     # Cast to uint64 to ensure to allow for maximal flexibility.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    val = np.array(val, dtype=np.uint64)
+    val = np.array(val, dtype=np.uint32)
 
     nstrs = []
     for pow in range(31):

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -76,6 +76,10 @@ def get_flags_str(val, name_map=None):
     if name_map is None:
         name_map = NAME_MAP
 
+    if val < 0 or val >= 2**32:
+        import warnings
+        warnings.warn(f"Flag value {val} is out of range [0, 2**32).")
+
     nstrs = []
     for pow in range(31):
         fval = 2**pow

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -77,9 +77,9 @@ def get_flags_str(val, name_map=None):
         name_map = NAME_MAP
 
     nstrs = []
-    for pow in range(32):
+    for pow in range(31):
         fval = 2**pow
-        if ((np.uint32(val) & fval) != 0):
+        if ((np.array(val).astype(np.uint32) & fval) != 0):
             if fval in name_map:
                 nstrs.append(name_map[fval])
             else:

--- a/ngmix/gaussap.py
+++ b/ngmix/gaussap.py
@@ -5,6 +5,7 @@ import logging
 import numpy as np
 from .gmix import GMixModel, GMixCM
 from .gexceptions import GMixRangeError
+from ngmix.defaults import copy_if_needed
 from ngmix.flags import NO_ATTEMPT, GMIX_RANGE_ERROR
 
 DEFAULT_FLUX = np.nan
@@ -117,10 +118,10 @@ def _prepare(pars,
              TdByTe=None,
              mask=None):
 
-    pars = np.array(pars, dtype='f8', ndmin=2, copy=False)
+    pars = np.array(pars, dtype='f8', ndmin=2, copy=copy_if_needed)
 
     if mask is not None:
-        mask = np.array(mask, dtype=bool, ndmin=1, copy=False)
+        mask = np.array(mask, dtype=bool, ndmin=1, copy=copy_if_needed)
         assert mask.shape[0] == pars.shape[0], \
             'mask and pars must be same length'
     else:
@@ -128,8 +129,8 @@ def _prepare(pars,
 
     if model == 'cm':
 
-        fracdev = np.array(fracdev, dtype='f8', ndmin=1, copy=False)
-        TdByTe = np.array(TdByTe, dtype='f8', ndmin=1, copy=False)
+        fracdev = np.array(fracdev, dtype='f8', ndmin=1, copy=copy_if_needed)
+        TdByTe = np.array(TdByTe, dtype='f8', ndmin=1, copy=copy_if_needed)
         assert fracdev.size == pars.shape[0], 'fracdev/pars must be same size'
         assert TdByTe.size == pars.shape[0], 'TdByTe/pars must be same length'
 

--- a/ngmix/priors/priors.py
+++ b/ngmix/priors/priors.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..gexceptions import GMixRangeError
 from .random import make_rng
-from ..defaults import LOWVAL
+from ..defaults import LOWVAL, copy_if_needed
 
 
 class PriorBase(object):
@@ -260,7 +260,7 @@ class TwoSidedErf(PriorBase):
             The locations at which to evaluate
         """
 
-        vals = np.array(vals, ndmin=1, dtype="f8", copy=False)
+        vals = np.array(vals, ndmin=1, dtype="f8", copy=copy_if_needed)
         pvals = np.zeros(vals.size)
 
         for i in range(vals.size):
@@ -309,7 +309,7 @@ class TwoSidedErf(PriorBase):
         vals: number
             The locations at which to evaluate
         """
-        vals = np.array(vals, ndmin=1, dtype="f8", copy=False)
+        vals = np.array(vals, ndmin=1, dtype="f8", copy=copy_if_needed)
         fdiff = np.zeros(vals.size)
 
         for i in range(vals.size):
@@ -780,7 +780,7 @@ class LogNormal(PriorBase):
         vals: array
             The locations at which to evaluate
         """
-        vals = np.array(vals, dtype="f8", copy=False)
+        vals = np.array(vals, dtype="f8", copy=copy_if_needed)
         if self.shift is not None:
             vals = vals - self.shift
 

--- a/ngmix/priors/shape.py
+++ b/ngmix/priors/shape.py
@@ -10,7 +10,7 @@ from .random import srandu
 from .priors import PriorBase
 import logging
 from ..util import print_pars
-from ..defaults import LOWVAL
+from ..defaults import LOWVAL, copy_if_needed
 
 LOGGER = logging.getLogger(__name__)
 
@@ -115,8 +115,8 @@ class GPriorBase(PriorBase):
         Get the 2d prior for the array inputs
         """
 
-        g1arr = array(g1arr, dtype="f8", copy=False)
-        g2arr = array(g2arr, dtype="f8", copy=False)
+        g1arr = array(g1arr, dtype="f8", copy=copy_if_needed)
+        g2arr = array(g2arr, dtype="f8", copy=copy_if_needed)
 
         output = numpy.zeros(g1arr.size) + LOWVAL
         self.fill_lnprob_array2d(g1arr, g2arr, output)
@@ -133,8 +133,8 @@ class GPriorBase(PriorBase):
         Get the 2d prior for the array inputs
         """
 
-        g1arr = array(g1arr, dtype="f8", copy=False)
-        g2arr = array(g2arr, dtype="f8", copy=False)
+        g1arr = array(g1arr, dtype="f8", copy=copy_if_needed)
+        g2arr = array(g2arr, dtype="f8", copy=copy_if_needed)
 
         output = numpy.zeros(g1arr.size)
         self.fill_prob_array2d(g1arr, g2arr, output)
@@ -151,7 +151,7 @@ class GPriorBase(PriorBase):
         Get the 1d prior for the array inputs
         """
 
-        garr = array(garr, dtype="f8", copy=False)
+        garr = array(garr, dtype="f8", copy=copy_if_needed)
 
         output = numpy.zeros(garr.size)
         self.fill_prob_array1d(garr, output)
@@ -726,8 +726,8 @@ class ZDisk2D(PriorBase):
         """
         get prob at the input positions
         """
-        x = numpy.array(x, dtype="f8", ndmin=1, copy=False)
-        y = numpy.array(y, dtype="f8", ndmin=1, copy=False)
+        x = numpy.array(x, dtype="f8", ndmin=1, copy=copy_if_needed)
+        y = numpy.array(y, dtype="f8", ndmin=1, copy=copy_if_needed)
         out = numpy.zeros(x.size, dtype="f8")
 
         r2 = x ** 2 + y ** 2

--- a/ngmix/shape.py
+++ b/ngmix/shape.py
@@ -1,5 +1,6 @@
 import numpy
 
+from .defaults import copy_if_needed
 from .gexceptions import GMixRangeError
 
 ONE_MINUS_EPS = 0.9999999999999999
@@ -362,8 +363,8 @@ def e1e2_to_eta1eta2(e1, e2):
     """
 
     if not isinstance(e1, numpy.ndarray):
-        e1 = numpy.array(e1, ndmin=1, copy=False)
-        e2 = numpy.array(e2, ndmin=1, copy=False)
+        e1 = numpy.array(e1, ndmin=1, copy=copy_if_needed)
+        e2 = numpy.array(e2, ndmin=1, copy=copy_if_needed)
         is_scalar = True
     else:
         is_scalar = False
@@ -408,8 +409,8 @@ def eta1eta2_to_g1g2(eta1, eta2):
     """
 
     if not isinstance(eta1, numpy.ndarray):
-        eta1 = numpy.array(eta1, ndmin=1, copy=False)
-        eta2 = numpy.array(eta2, ndmin=1, copy=False)
+        eta1 = numpy.array(eta1, ndmin=1, copy=copy_if_needed)
+        eta2 = numpy.array(eta2, ndmin=1, copy=copy_if_needed)
         is_scalar = True
     else:
         is_scalar = False

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -11,8 +11,6 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
     # Set a high-enough bit in addition to the lower bit to ensure things work.
-    val = np.array(LOW_DET, dtype=dtype)
-    if val.itemsize > 4 and dtype not in (np.uint64, ):
-        val |= 2**45
+    val = np.array(LOW_DET | 2**45).astype(dtype)
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -11,6 +11,8 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
     # Set a high-enough bit in addition to the lower bit to ensure things work.
-    val = np.array(LOW_DET | 2**45, dtype=dtype)
+    val = np.array(LOW_DET, dtype=dtype)
+    if val.itemsize > 4:
+        val |= 2**45
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -12,7 +12,7 @@ def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
     # Set a high-enough bit in addition to the lower bit to ensure things work.
     val = np.array(LOW_DET, dtype=dtype)
-    if val.itemsize > 4:
+    if val.itemsize > 4 and dtype not in (np.uint64, ):
         val |= 2**45
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -5,7 +5,8 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 
 
 @pytest.mark.parametrize(
-    "dtype", [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]
+    "dtype", [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64,
+              np.uint64]
 )
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -11,6 +11,9 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
     # Set a high-enough bit in addition to the lower bit to ensure things work.
+    # This should be a flag that is defined in NAME_MAP.
+    # When converting to a type with fewer bits, only the least-significant
+    # bits are kept and the more-significant bits are discarded.
     val = np.array(LOW_DET | 2**45).astype(dtype)
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -14,6 +14,9 @@ def test_get_flags_str(dtype):
     # This should be a flag that is defined in NAME_MAP.
     # When converting to a type with fewer bits, only the least-significant
     # bits are kept and the more-significant bits are discarded.
-    val = np.array(LOW_DET | 2**45).astype(dtype)
+    bit_string = LOW_DET | 2 ** 45
+    val = np.array(bit_string).astype(dtype)
+    # Check that the least signficant bits are kept.
+    assert val == (bit_string) & (2**(8*val.itemsize) - 1)  # itemsize is in bytes.
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+import pytest
+from ..flags import get_flags_str, NAME_MAP, LOW_DET
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64, np.uint64]
+)
+def test_get_flags_str(dtype):
+    """Test that get_flags_str works for different integer types."""
+    val = np.array(LOW_DET, dtype=dtype)
+    flag_str = get_flags_str(val, NAME_MAP)
+    assert flag_str == NAME_MAP[LOW_DET]

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -10,6 +10,7 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 )
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
-    val = np.array(LOW_DET, dtype=dtype)
+    # Set a high-enough bit in addition to the lower bit to ensure things work.
+    val = np.array(LOW_DET | 2**45, dtype=dtype)
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]


### PR DESCRIPTION
This PR makes `ngmix` compatible with `numpy>=2` and `numpy<2`.

The recommended method is to replace `np.array(..., copy=False)` with `np.asarray` [link](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword). However, given the necessity of `ndmin` which is not available in `asarray`, I took the [scipy approach](https://github.com/scipy/scipy/pull/20172) here.