### PR TITLE
Allow independent handling of noshear in metacal

### DIFF
--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -165,7 +165,9 @@ class MetacalDilatePSF(object):
         for type in types:
             sh = shdict[type]
 
-            if (type == 'noshear') and (len(types) == 1):
+            if (type == 'noshear') and (
+                len([type for type in types if 'psf' not in type]) == 1
+            ):
                 # only need noshear
                 _newpsf_image, _newpsf_obj = self.get_target_psf(sh, 'gal_shear')
                 _unsheared_image = self.get_target_image(_newpsf_obj, shear=None)

--- a/ngmix/metacal/metacal.py
+++ b/ngmix/metacal/metacal.py
@@ -143,15 +143,11 @@ class MetacalDilatePSF(object):
             for t in types:
                 assert t in METACAL_TYPES, 'bad metacal type: %s' % t
 
-        # we add 1p here if we want noshear since we get both of those
-        # at once below
-
-        if 'noshear' in types and '1p' not in types:
-            types.append('1p')
-
         shdict = {}
 
         # galshear keys
+        shdict['noshear'] = Shape(0.0, 0.0)
+
         shdict['1m'] = Shape(-step, 0.0)
         shdict['1p'] = Shape(+step, 0.0)
 
@@ -167,16 +163,19 @@ class MetacalDilatePSF(object):
         odict = {}
 
         for type in types:
-            if type == 'noshear':
-                # we get noshear with 1p
-                continue
-
             sh = shdict[type]
+
+            if (type == 'noshear') and (len(types) == 1):
+                # only need noshear
+                _newpsf_image, _newpsf_obj = self.get_target_psf(sh, 'gal_shear')
+                _unsheared_image = self.get_target_image(_newpsf_obj, shear=None)
+                obs = self._make_obs(_unsheared_image, _newpsf_image)
+                obs.psf.galsim_obj = _newpsf_obj
 
             if 'psf' in type:
                 obs = self.get_obs_psfshear(sh)
             else:
-                if type == '1p':
+                if ("noshear" in types) and ("noshear" not in odict.keys()):
                     # add in noshear from this one
                     obs, obs_noshear = self.get_obs_galshear(
                         sh,

--- a/ngmix/tests/test_metacal.py
+++ b/ngmix/tests/test_metacal.py
@@ -85,14 +85,46 @@ def test_metacal_types_smoke(psf, metacal_caching):
     if psf == 'galsim_obj':
         psf = galsim.Gaussian(fwhm=0.9)
 
-    # shuld automatically add 1p
+    # test with only noshear
     types = ['noshear']
     obs_dict = ngmix.metacal.get_all_metacal(
         obs, rng=rng, psf=psf, types=types,
     )
 
     assert len(obs_dict) == len(types)
-    for type in types + ['1p']:
+    for type in types:
+        assert type in obs_dict
+
+        mobs = obs_dict[type]
+        assert mobs.image.shape == obs.image.shape
+        assert np.all(mobs.image != obs.image)
+        assert mobs.psf.image.shape == obs.psf.image.shape
+        assert np.all(mobs.psf.image != obs.psf.image)
+
+    # test with noshear and another shear
+    types = ['noshear', '1m']
+    obs_dict = ngmix.metacal.get_all_metacal(
+        obs, rng=rng, psf=psf, types=types,
+    )
+
+    assert len(obs_dict) == len(types)
+    for type in types:
+        assert type in obs_dict
+
+        mobs = obs_dict[type]
+        assert mobs.image.shape == obs.image.shape
+        assert np.all(mobs.image != obs.image)
+        assert mobs.psf.image.shape == obs.psf.image.shape
+        assert np.all(mobs.psf.image != obs.psf.image)
+
+    # test with other shears
+    types = ['1p', '1m']
+    obs_dict = ngmix.metacal.get_all_metacal(
+        obs, rng=rng, psf=psf, types=types,
+    )
+
+    assert len(obs_dict) == len(types)
+    for type in types:
         assert type in obs_dict
 
         mobs = obs_dict[type]


### PR DESCRIPTION
Proposed solution for #250. Rather than forcing the processing of `1p` if `noshear` is specified, this updates the code to check
1. if _only_ `noshear` is requested, then process that independently
2. if `noshear` and other types are requested, if `noshear` has not yet been run, process that alongside another type

The code produces the desired behavior but there are no tests yet. I'm happy to implement one (probably something that quickly runs metacal with a few different types requests and checks that the output dict has the same types as requested)