### PR TITLE
Get Moffat and other galsim fitters on interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### New features
 
+    - Allow fwhm as size for Moffat galsim fitter
     - Added method scale_T() to gausian mixtures.
 
 ### Bug Fixes
@@ -9,6 +10,9 @@
     - em prep_obs now does a full copy of the Observation
     - Deal with possible zero division in get_weighted_sums
     - Fix location of np.linalg.LinAlgError
+    - Galsim fitters get_band_pars did not conform to the
+      Fitter interface.  The first parameters has been
+      ranamed to pars (from pars_in).
 
 ### Unit Tests
 

--- a/ngmix/fitting/galsim_fitters.py
+++ b/ngmix/fitting/galsim_fitters.py
@@ -99,16 +99,24 @@ class GalsimMoffatFitter(GalsimFitter):
     prior: ngmix prior, optional
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
+    size_type: string
+        How pars[4] should be interpreted.  Default is 'r50' but
+        also valid is 'fwhm', 'half_light_radius' and 'hlr'.
+
+        The default of r50 was a mistake, but is kept for backward
+        compatibility.
     fit_pars: dict, optional
         parameters for the lm fitter, e.g. maxfev, ftol, xtol
     """
 
-    def __init__(self, prior=None, fit_pars=None):
+    def __init__(self, prior=None, size_type='r50', fit_pars=None):
+        self.size_type = size_type
         super().__init__(model="moffat", prior=prior, fit_pars=fit_pars)
 
     def _make_fit_model(self, obs, guess):
         return GalsimMoffatFitModel(
             obs=obs, guess=guess, prior=self.prior,
+            size_type=self.size_type,
         )
 
 

--- a/ngmix/fitting/galsim_results.py
+++ b/ngmix/fitting/galsim_results.py
@@ -175,18 +175,18 @@ class GalsimFitModel(FitModel):
         else:
             raise NotImplementedError("can't fit '%s'" % self.model)
 
-    def get_band_pars(self, pars_in, band):
+    def get_band_pars(self, pars, band):
         """
         Get pars for the specified band
 
         input pars are [c1, c2, e1, e2, r50, flux1, flux2, ....]
         """
 
-        pars = self._band_pars
+        band_pars = self._band_pars
 
-        pars[0:5] = pars_in[0:5]
-        pars[5] = pars_in[5 + band]
-        return pars
+        band_pars[0:5] = pars[0:5]
+        band_pars[5] = pars[5 + band]
+        return band_pars
 
     def _set_totpix(self):
         """
@@ -403,18 +403,18 @@ class GalsimSpergelFitModel(GalsimFitModel):
 
         return gal
 
-    def get_band_pars(self, pars_in, band):
+    def get_band_pars(self, pars, band):
         """
         Get linear pars for the specified band
 
         input pars are [c1, c2, e1, e2, r50, nu, flux1, flux2, ....]
         """
 
-        pars = self._band_pars
+        band_pars = self._band_pars
 
-        pars[0:6] = pars_in[0:6]
-        pars[6] = pars_in[6 + band]
-        return pars
+        band_pars[0:6] = pars[0:6]
+        band_pars[6] = pars[6 + band]
+        return band_pars
 
     def _set_n_prior_pars(self):
         if self.prior is None:
@@ -435,12 +435,19 @@ class GalsimMoffatFitModel(GalsimFitModel):
         Observation, ObsList, or MultiBandObsList
     guess: array-like
         starting parameters for the lm fitter
+    size_type: string
+        How pars[4] should be interpreted.  Default is 'r50' but
+        also valid is 'fwhm', 'half_light_radius' and 'hlr'
+
+        The default of r50 was a mistake, but is kept for backward
+        compatibility.
     prior: ngmix prior, optional
         For example ngmix.priors.PriorSimpleSep can
         be used as a separable prior on center, g, size, flux.
     """
 
-    def __init__(self, obs, guess, prior=None):
+    def __init__(self, obs, guess, size_type='r50', prior=None):
+        self.size_type = size_type
         super().__init__(obs=obs, model='moffat', guess=guess, prior=prior)
 
     def _set_model_class(self):
@@ -454,30 +461,38 @@ class GalsimMoffatFitModel(GalsimFitModel):
         """
         import galsim
 
-        r50 = pars[4]
-        beta = pars[5]
-        flux = pars[6]
+        kw = {
+            'beta': pars[5],
+            'flux': pars[6],
+        }
+
+        if self.size_type in ['r50', 'half_light_radius', 'hlr']:
+            kw['half_light_radius'] = pars[4]
+        elif self.size_type == 'fwhm':
+            kw['fwhm'] = pars[4]
+        else:
+            raise ValueError(f'bad size_type {self.size_type}')
 
         # generic RuntimeError thrown
         try:
-            gal = galsim.Moffat(beta, half_light_radius=r50, flux=flux,)
+            gal = galsim.Moffat(**kw)
         except RuntimeError as err:
             raise GMixRangeError(str(err))
 
         return gal
 
-    def get_band_pars(self, pars_in, band):
+    def get_band_pars(self, pars, band):
         """
         Get linear pars for the specified band
 
         input pars are [c1, c2, e1, e2, r50, beta, flux1, flux2, ....]
         """
 
-        pars = self._band_pars
+        band_pars = self._band_pars
 
-        pars[0:6] = pars_in[0:6]
-        pars[6] = pars_in[6 + band]
-        return pars
+        band_pars[0:6] = pars[0:6]
+        band_pars[6] = pars[6 + band]
+        return band_pars
 
     def _set_prior(self, prior=None):
         self.prior = prior

--- a/ngmix/tests/test_ml_fitting_galsim.py
+++ b/ngmix/tests/test_ml_fitting_galsim.py
@@ -271,7 +271,7 @@ def test_ml_fitting_galsim_moffat_smoke():
         jacobian=jac,
     )
 
-    fitter = ngmix.fitting.GalsimMoffatFitter()
+    fitter = ngmix.fitting.GalsimMoffatFitter(size_type='fwhm')
 
     guess = np.zeros(7)
 
@@ -279,7 +279,7 @@ def test_ml_fitting_galsim_moffat_smoke():
     guess[1] = rng.uniform(low=-0.1, high=0.1)
     guess[2] = rng.uniform(low=-0.1, high=0.1)
     guess[3] = rng.uniform(low=-0.1, high=0.1)
-    guess[4] = moff.half_light_radius * rng.uniform(low=0.9, high=1.1)
+    guess[4] = moff.fwhm * rng.uniform(low=0.9, high=1.1)
     guess[5] = rng.uniform(low=1.5, high=3)
     guess[6] = flux * rng.uniform(low=0.9, high=1.1)
 


### PR DESCRIPTION
Also Moffat can now use FWHM as the size parameters Default was r50 which was a mistake, but for now keeping it for backwards compat.