### PR TITLE
Avoid slowdown in get_flags_str

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,10 @@ jobs:
             pytest-xdist \
             flaky
 
+          if [[ "${{ matrix.pyver }}" == "3.9" ]]; then
+            conda install numpy=1
+          fi
+
           python -m pip install -e .
 
       - name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: ["3.9", "3.10", "3.11", "3.12"]
+        pyver: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: "ubuntu-latest"
 

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+.vscode/*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
     - Fix bug in unit test where meds writing failed
     - Added unit test of gmix scale_T()
 
+### Performance
+
+    - Avoid slowdown in get_flags_str due to type casting
+
 ## v2.4.0
 
 ### New features

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -84,7 +84,7 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    val = np.array(val, dtype=np.uint32)
+    val = np.asarray([val], dtype=np.uint32)[0]
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -93,7 +93,7 @@ def get_flags_str(val, name_map=None):
         # The bitwise & operation with this mask sets all bits 32 and higher
         # to zero. Thus the resulting int will fit into a unit32 numpy type.
         val = val & 0xFFFFFFFF
-    val = np.asarray(val, dtype=np.uint32)[0]
+    val = np.asarray([val], dtype=np.uint32)[0]
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -63,7 +63,8 @@ def get_flags_str(val, name_map=None):
     Parameters
     ----------
     val : int
-        The flag value. This must be non-negative.
+        The flag value. This must be non-negative. Only the first 32 bits
+        (0 to 31) are considered. Any bits beyond this are ignored.
     name_map : dict, optional
         A dictionary mapping values to names. Default is global at
         ngmix.flags.NAME_MAP.

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -85,15 +85,7 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    if isinstance(val, int):
-        # Python 3.9 doesn't like to compute bitwise & with uint64 types,
-        # so we only do this for python ints where it is needed.
-        # The value 0xFFFFFFFF is an int with bits 0 to 31 (inclusive)
-        # set to 1 and the rest set to 0.
-        # The bitwise & operation with this mask sets all bits 32 and higher
-        # to zero. Thus the resulting int will fit into a unit32 numpy type.
-        val = val & 0xFFFFFFFF
-    val = np.asarray(val, dtype=np.uint32)
+    val = np.asarray(val).astype(np.uint32)
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -93,7 +93,7 @@ def get_flags_str(val, name_map=None):
         # The bitwise & operation with this mask sets all bits 32 and higher
         # to zero. Thus the resulting int will fit into a unit32 numpy type.
         val = val & 0xFFFFFFFF
-    val = np.asarray([val], dtype=np.uint32)
+    val = np.asarray([val], dtype=np.uint32)[0]
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -85,6 +85,12 @@ def get_flags_str(val, name_map=None):
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
     if isinstance(val, int):
+        # Python 3.9 doesn't like to compute bitwise & with uint64 types,
+        # so we only do this for python ints where it is needed.
+        # The value 0xFFFFFFFF is an int with bits 0 to 31 (inclusive)
+        # set to 1 and the rest set to 0.
+        # The bitwise & operation with this mask sets all bits 32 and higher
+        # to zero. Thus the resulting int will fit into a unit32 numpy type.
         val = val & 0xFFFFFFFF
     val = np.asarray([val], dtype=np.uint32)
 

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -85,7 +85,15 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    val = np.asarray(val).astype(np.uint32)
+    if isinstance(val, int):
+        # Python 3.9 doesn't like to compute bitwise & with uint64 types,
+        # so we only do this for python ints where it is needed.
+        # The value 0xFFFFFFFF is an int with bits 0 to 31 (inclusive)
+        # set to 1 and the rest set to 0.
+        # The bitwise & operation with this mask sets all bits 32 and higher
+        # to zero. Thus the resulting int will fit into a unit32 numpy type.
+        val = val & 0xFFFFFFFF
+    val = np.asarray(val, dtype=np.uint32)[0]
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -84,9 +84,9 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    if val >= 2**32:
+    if isinstance(val, int):
         val = val & 0xFFFFFFFF
-    val = np.uint32(val)
+    val = np.asarray([val], dtype=np.uint32)
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -84,7 +84,7 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
-    val = np.asarray([val], dtype=np.uint32)[0]
+    val = np.uint32(val)
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -93,7 +93,7 @@ def get_flags_str(val, name_map=None):
         # The bitwise & operation with this mask sets all bits 32 and higher
         # to zero. Thus the resulting int will fit into a unit32 numpy type.
         val = val & 0xFFFFFFFF
-    val = np.asarray([val], dtype=np.uint32)[0]
+    val = np.asarray(val, dtype=np.uint32)
 
     nstrs = []
     fval = 1

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -87,11 +87,12 @@ def get_flags_str(val, name_map=None):
     val = np.array(val, dtype=np.uint32)
 
     nstrs = []
+    fval = 1
     for pow in range(31):
-        fval = 2**pow
         if ((val & fval) != 0):
             if fval in name_map:
                 nstrs.append(name_map[fval])
             else:
                 nstrs.append("bit 2**%d" % pow)
+        fval *= 2
     return "|".join(nstrs)

--- a/ngmix/flags.py
+++ b/ngmix/flags.py
@@ -84,6 +84,8 @@ def get_flags_str(val, name_map=None):
     # Cast to uint32 is sufficient given the range of flags.
     # This is because the second argument to the bitwise AND operator (&) below
     # would get implicitly cast to the same type as `val`.
+    if val >= 2**32:
+        val = val & 0xFFFFFFFF
     val = np.uint32(val)
 
     nstrs = []

--- a/ngmix/tests/test_flags.py
+++ b/ngmix/tests/test_flags.py
@@ -6,7 +6,7 @@ from ..flags import get_flags_str, NAME_MAP, LOW_DET
 
 @pytest.mark.parametrize(
     "dtype", [np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32, np.int64,
-              np.uint64]
+              np.uint64, None]
 )
 def test_get_flags_str(dtype):
     """Test that get_flags_str works for different integer types."""
@@ -15,8 +15,11 @@ def test_get_flags_str(dtype):
     # When converting to a type with fewer bits, only the least-significant
     # bits are kept and the more-significant bits are discarded.
     bit_string = LOW_DET | 2 ** 45
-    val = np.array(bit_string).astype(dtype)
-    # Check that the least signficant bits are kept.
-    assert val == (bit_string) & (2**(8*val.itemsize) - 1)  # itemsize is in bytes.
+    if dtype is not None:
+        val = np.array(bit_string).astype(dtype)
+        # Check that the least signficant bits are kept.
+        assert val == (bit_string) & (2**(8*val.itemsize) - 1)  # itemsize is in bytes.
+    else:
+        val = bit_string
     flag_str = get_flags_str(val, NAME_MAP)
     assert flag_str == NAME_MAP[LOW_DET]


### PR DESCRIPTION
In #248 , we introduced safe casting to `uint32`, but it seemed to have significantly slowdown the bitwise AND operation that follows. In DP2 production, the calls to `get_flags_str` are taking a significant amount of time, and this is a low-hanging fruit to fix. Along with it is another minor optimization calculating powers of 2 cumulatively. Together, this brings down the per-call time from ~50 μs to ~8 μs, which is a signficant gain given how many times this functions gets called.