### PR TITLE
LM noise cov

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
       fitters use a fixed weight, the resulting covariances are exact
       for stationary correlated noise, such as that induced by
       metacal.
+    - A similar update for the Fitters that use LM, taking in
+      a noise image to estimate the noise power per mode and
+      give good errors even in the presence of correlated noise.
     - Allow fwhm as size for Moffat galsim fitter
     - Added method scale_T() to gausian mixtures.
     - Added new metacal psf reconvolution method 'azgauss',

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## v2.4.1 (not yet released)
+## v2.4.2 (not yet released)
 
 ### New features
 
@@ -12,6 +12,20 @@
     - A similar update for the Fitters that use LM, taking in
       a noise image to estimate the noise power per mode and
       give good errors even in the presence of correlated noise.
+
+### New features
+
+    - Allow fwhm as size for Moffat galsim fitter
+    - Added method scale_T() to gausian mixtures.
+    - Added new metacal psf reconvolution method 'azgauss',
+      which is a noise-robust version of the old 'gauss'
+      method.
+
+
+## v2.4.1
+
+### New features
+
     - Allow fwhm as size for Moffat galsim fitter
     - Added method scale_T() to gausian mixtures.
     - Added new metacal psf reconvolution method 'azgauss',

--- a/ngmix/_version.py
+++ b/ngmix/_version.py
@@ -1,1 +1,1 @@
-__version__ = '2.4.1'  # noqa
+__version__ = '2.4.2'  # noqa

--- a/ngmix/fitting/fitters.py
+++ b/ngmix/fitting/fitters.py
@@ -6,6 +6,7 @@ __all__ = ['Fitter', 'CoellipFitter', 'PSFFluxFitter']
 import logging
 
 from .leastsqbound import run_leastsq
+from .noise_cov import apply_noise_cov
 from .. import gmix
 from ..defaults import DEFAULT_LM_PARS
 from .results import FitModel, CoellipFitModel, PSFFluxFitModel
@@ -25,12 +26,22 @@ class Fitter(object):
         A prior for fitting
     fit_pars: dict
         Parameters to send to the leastsq fitting routine
+    use_noise_image: bool, optional
+        If True, replace the chi^2-scaled LM covariance with the
+        noise-power sandwich covariance, with the per-mode noise
+        power measured from the noise image attached to each
+        observation (obs.noise).  Use this to get accurate
+        parameter errors in the presence of stationary correlated
+        noise, such as that induced by coadding or metacal.  The
+        noise image must be an independent realization of the
+        noise, in the same frame as the image.  Default False.
     """
 
-    def __init__(self, model, prior=None, fit_pars=None):
+    def __init__(self, model, prior=None, fit_pars=None, use_noise_image=False):
         self.prior = prior
         self.model = gmix.get_model_num(model)
         self.model_name = gmix.get_model_name(self.model)
+        self.use_noise_image = use_noise_image
 
         if fit_pars is not None:
             self.fit_pars = fit_pars.copy()
@@ -57,6 +68,15 @@ class Fitter(object):
 
         fit_model = self._make_fit_model(obs=obs, guess=guess)
 
+        if self.use_noise_image:
+            for obslist in fit_model.obs:
+                for tobs in obslist:
+                    if not tobs.has_noise():
+                        raise ValueError(
+                            'obs.noise must be set when '
+                            'use_noise_image=True'
+                        )
+
         result = run_leastsq(
             fit_model.calc_fdiff,
             guess=guess,
@@ -64,6 +84,9 @@ class Fitter(object):
             bounds=fit_model.bounds,
             **self.fit_pars
         )
+
+        if self.use_noise_image:
+            apply_noise_cov(fit_model=fit_model, result=result)
 
         fit_model.set_fit_result(result)
         return fit_model

--- a/ngmix/fitting/noise_cov.py
+++ b/ngmix/fitting/noise_cov.py
@@ -1,0 +1,166 @@
+"""
+Sandwich covariance for LM fits under stationary correlated noise,
+using the per-mode noise power measured from noise images attached
+to the observations, in the same spirit as use_noise_image for the
+pre-psf moment fitters.
+
+The LM machinery reports pars_cov0 * chi2/dof, which only adapts to
+the overall pixel variance.  Under stationary correlated noise the
+covariance of the weighted least squares estimator is the sandwich
+
+    Cov = A^-1 B A^-1
+
+where A^-1 = pars_cov0 is the curvature at the solution (including
+any prior curvature, which shapes the estimator's response) and
+
+    B_ab = sum_epochs sum_q conj(G_a) G_b |n~(q)|^2 / N^2
+
+with G_a = fft2(weight * dmodel/dp_a) the influence kernel of
+parameter a and n~ the fft of the epoch's noise image.  For white
+noise at the weight-map level B reduces to the data block of A and
+the sandwich returns pars_cov0.
+
+The noise image attached to each observation must be an independent
+realization of the noise, in the same frame as the image.
+"""
+__all__ = ['calc_noise_cov', 'apply_noise_cov']
+
+import numpy as np
+
+from .. import gmix
+from .leastsqbound import _test_cov, _get_def_stuff
+
+# absolute floors for the numerical derivative steps; the
+# centroid pars are in sky units, T in arcsec^2, flux in
+# image units
+STEP_CEN = 1.0e-3
+STEP_SHAPE = 1.0e-4
+STEP_STRUCT_MIN = 1.0e-4
+STEP_FLUX_MIN = 1.0e-6
+STEP_FRAC = 1.0e-3
+
+
+def apply_noise_cov(fit_model, result):
+    """
+    Replace the chi^2-scaled LM covariance in the result with the
+    noise-power sandwich covariance.  No-op unless the fit
+    succeeded and the curvature is usable.  On a bad sandwich
+    covariance the covariance test flags are set and the errors
+    are set to the defaults, as in run_leastsq.
+
+    Parameters
+    ----------
+    fit_model: FitModel
+        The fit model holding the observations, model and band
+        parameter mapping
+    result: dict
+        The result dict from run_leastsq, modified in place
+    """
+    if result['flags'] != 0:
+        return
+    pcov0 = result.get('pars_cov0')
+    if pcov0 is None or not np.all(np.isfinite(pcov0)):
+        return
+
+    cov = calc_noise_cov(
+        fit_model=fit_model, pars=result['pars'], pars_cov0=pcov0,
+    )
+
+    npars = result['pars'].size
+    if not np.all(np.isfinite(cov)):
+        cflags = _test_cov(np.diag(np.full(npars, -1.0)))
+    else:
+        cflags = _test_cov(cov)
+
+    if cflags != 0:
+        result['flags'] |= cflags
+        result['errmsg'] = 'bad noise covariance matrix'
+        _, result['pars_cov'], result['pars_err'] = (
+            _get_def_stuff(npars)
+        )
+    else:
+        result['pars_cov'] = cov
+        result['pars_err'] = np.sqrt(np.diag(cov))
+
+
+def calc_noise_cov(fit_model, pars, pars_cov0):
+    """
+    Calculate the sandwich covariance pars_cov0 B pars_cov0 with B
+    accumulated from the per-mode noise power of every epoch's
+    attached noise image.
+
+    Parameters
+    ----------
+    fit_model: FitModel
+        The fit model holding the observations, model and band
+        parameter mapping
+    pars: array
+        Parameters at the solution
+    pars_cov0: array
+        The unscaled covariance (J^T J)^-1 from the fit
+
+    Returns
+    -------
+    cov: (npars, npars) array
+    """
+    npars = pars.size
+    nband = fit_model.nband
+    nshape = npars - nband
+
+    B = np.zeros((npars, npars))
+    for band in range(nband):
+        kpars = list(range(nshape)) + [nshape + band]
+        for obs in fit_model.obs[band]:
+            kernels = [
+                np.fft.fft2(
+                    obs.weight * _dmodel(
+                        fit_model=fit_model, pars=pars, ipar=a,
+                        band=band, obs=obs,
+                    )
+                )
+                for a in kpars
+            ]
+            p = np.abs(np.fft.fft2(obs.noise)) ** 2
+            n = obs.image.size
+            for ia in range(len(kpars)):
+                for ib in range(ia, len(kpars)):
+                    val = np.sum(
+                        np.conj(kernels[ia]) * kernels[ib] * p
+                    ).real / n ** 2
+                    B[kpars[ia], kpars[ib]] += val
+                    if ib != ia:
+                        B[kpars[ib], kpars[ia]] += val
+
+    return pars_cov0 @ B @ pars_cov0
+
+
+def _dmodel(fit_model, pars, ipar, band, obs):
+    """central difference derivative image of the convolved model
+    with respect to one parameter"""
+    step = _get_step(pars=pars, ipar=ipar, nband=fit_model.nband)
+
+    ims = []
+    for sign in (1, -1):
+        p = pars.copy()
+        p[ipar] += sign * step
+        band_pars = fit_model.get_band_pars(pars=p, band=band)
+        gm = gmix.make_gmix_model(band_pars, fit_model.model)
+        if obs.has_psf_gmix():
+            gm = gm.convolve(obs.psf.gmix)
+        ims.append(gm.make_image(
+            obs.image.shape, jacobian=obs.jacobian,
+        ))
+    return (ims[0] - ims[1]) / (2 * step)
+
+
+def _get_step(pars, ipar, nband):
+    npars = pars.size
+    nshape = npars - nband
+    if ipar < 2:
+        return STEP_CEN
+    elif ipar < 4:
+        return STEP_SHAPE
+    elif ipar < nshape:
+        return max(STEP_STRUCT_MIN, STEP_FRAC * abs(pars[ipar]))
+    else:
+        return max(STEP_FLUX_MIN, STEP_FRAC * abs(pars[ipar]))

--- a/ngmix/tests/test_fitting_noise_cov.py
+++ b/ngmix/tests/test_fitting_noise_cov.py
@@ -1,0 +1,199 @@
+"""
+Tests for the noise-power sandwich covariance available through
+Fitter(..., use_noise_image=True).
+
+The closure tests fit an exp model to many noise realizations and
+compare the empirical scatter of the recovered flux to the
+reported errors via pulls:
+
+  white noise      the sandwich must agree with the standard LM
+                   errors, and both must pull at 1
+  correlated noise (white noise convolved with a small kernel,
+                   weight map set to the true pixel variance so
+                   chi^2/dof is 1 and the standard errors do not
+                   adapt) the standard errors understate the flux
+                   variance; the sandwich must pull at 1
+"""
+import numpy as np
+import pytest
+
+import ngmix
+
+
+PIXEL_SCALE = 0.2
+PSF_FWHM = 0.8
+DIM = 49
+PSF_DIM = 33
+HLR = 0.5
+FLUX = 1000.0
+TGUESS = 0.36
+
+
+def _smooth(im, kernel):
+    from scipy.signal import fftconvolve
+    return fftconvolve(im, kernel, mode='same')
+
+
+def _make_obs(rng, sigma, kernel=None, nband=1, with_noise=True):
+    import galsim
+
+    psf = galsim.Gaussian(fwhm=PSF_FWHM)
+    psf_im = psf.drawImage(
+        nx=PSF_DIM, ny=PSF_DIM, scale=PIXEL_SCALE,
+    ).array
+    psf_cen = (PSF_DIM - 1) / 2
+    psf_jac = ngmix.DiagonalJacobian(
+        scale=PIXEL_SCALE, row=psf_cen, col=psf_cen,
+    )
+
+    gal = galsim.Convolve(
+        galsim.Exponential(half_light_radius=HLR, flux=FLUX),
+        psf,
+    )
+    im0 = gal.drawImage(
+        nx=DIM, ny=DIM, scale=PIXEL_SCALE,
+    ).array
+    cen = (DIM - 1) / 2
+    jac = ngmix.DiagonalJacobian(
+        scale=PIXEL_SCALE, row=cen, col=cen,
+    )
+
+    # fit the psf for the gmix used in convolution
+    psf_obs = ngmix.Observation(
+        psf_im.copy(),
+        weight=np.ones_like(psf_im) * 1.0e12,
+        jacobian=psf_jac,
+    )
+    am = ngmix.admom.AdmomFitter(rng=rng)
+    pres = am.go(psf_obs, guess=0.1)
+    psf_obs.set_gmix(pres.get_gmix())
+
+    mbobs = ngmix.MultiBandObsList()
+    for _ in range(nband):
+        nz = rng.normal(scale=sigma, size=im0.shape)
+        nz_extra = rng.normal(scale=sigma, size=im0.shape)
+        if kernel is not None:
+            nz = _smooth(nz, kernel)
+            nz_extra = _smooth(nz_extra, kernel)
+            pixvar = sigma ** 2 * np.sum(kernel ** 2)
+        else:
+            pixvar = sigma ** 2
+
+        kw = {}
+        if with_noise:
+            kw['noise'] = nz_extra
+        obs = ngmix.Observation(
+            im0 + nz,
+            weight=np.full(im0.shape, 1.0 / pixvar),
+            jacobian=jac,
+            psf=psf_obs.copy(),
+            **kw
+        )
+        obslist = ngmix.ObsList()
+        obslist.append(obs)
+        mbobs.append(obslist)
+    return mbobs
+
+
+def _get_prior(rng):
+    return ngmix.joint_prior.PriorSimpleSep(
+        cen_prior=ngmix.priors.CenPrior(
+            0.0, 0.0, PIXEL_SCALE, PIXEL_SCALE, rng=rng,
+        ),
+        g_prior=ngmix.priors.GPriorBA(0.3, rng=rng),
+        T_prior=ngmix.priors.TwoSidedErf(
+            -1.0, 0.1, 1.0e3, 1.0, rng=rng,
+        ),
+        F_prior=ngmix.priors.TwoSidedErf(
+            -1.0e2, 1.0, 1.0e9, 1.0e8, rng=rng,
+        ),
+    )
+
+
+def _fit_many(rng, sigma, kernel, use_noise_image, ntrial, nband=1):
+    prior = _get_prior(rng)
+    fitter = ngmix.fitting.Fitter(
+        model='exp', prior=prior,
+        use_noise_image=use_noise_image,
+    )
+    pulls = []
+    for _ in range(ntrial):
+        mbobs = _make_obs(rng, sigma, kernel=kernel, nband=nband)
+        guess = np.concatenate([
+            rng.uniform(-0.01, 0.01, 2),
+            rng.uniform(-0.02, 0.02, 2),
+            [TGUESS * rng.uniform(0.9, 1.1)],
+            FLUX * rng.uniform(0.9, 1.1, nband),
+        ])
+        res = fitter.go(obs=mbobs, guess=guess)
+        if res['flags'] != 0:
+            continue
+        flux = np.atleast_1d(res['flux'])
+        flux_err = np.atleast_1d(res['flux_err'])
+        pulls.append((flux - FLUX) / flux_err)
+    return np.array(pulls)
+
+
+def test_noise_cov_white_closure():
+    """on white noise the sandwich must agree with the standard
+    LM errors and pull at 1"""
+    rng = np.random.RandomState(11)
+    sigma = 8.0
+
+    pulls_std = _fit_many(
+        rng, sigma, kernel=None, use_noise_image=False, ntrial=100,
+    )
+    pulls_sand = _fit_many(
+        rng, sigma, kernel=None, use_noise_image=True, ntrial=100,
+    )
+    assert abs(pulls_std.std() - 1) < 0.2
+    assert abs(pulls_sand.std() - 1) < 0.2
+
+
+def test_noise_cov_correlated_closure():
+    """on correlated noise with an honest pixel-variance weight
+    map the standard errors understate the flux variance; the
+    sandwich must restore pulls of 1"""
+    rng = np.random.RandomState(31)
+    sigma = 8.0
+    kernel = np.ones((3, 3)) / 9
+
+    pulls_std = _fit_many(
+        rng, sigma, kernel=kernel, use_noise_image=False,
+        ntrial=100,
+    )
+    pulls_sand = _fit_many(
+        rng, sigma, kernel=kernel, use_noise_image=True,
+        ntrial=100,
+    )
+    # positively correlated noise inflates the flux variance well
+    # beyond the white expectation
+    assert pulls_std.std() > 1.5
+    assert abs(pulls_sand.std() - 1) < 0.2
+
+
+def test_noise_cov_multiband():
+    """multi-band fits get per-band sandwich flux errors"""
+    rng = np.random.RandomState(51)
+    sigma = 8.0
+    kernel = np.ones((3, 3)) / 9
+
+    pulls = _fit_many(
+        rng, sigma, kernel=kernel, use_noise_image=True,
+        ntrial=50, nband=3,
+    )
+    assert pulls.shape[1] == 3
+    for band in range(3):
+        assert abs(pulls[:, band].std() - 1) < 0.25
+
+
+def test_noise_cov_requires_noise():
+    """use_noise_image without an attached noise image raises"""
+    rng = np.random.RandomState(71)
+    mbobs = _make_obs(rng, 8.0, with_noise=False)
+    fitter = ngmix.fitting.Fitter(
+        model='exp', use_noise_image=True,
+    )
+    guess = np.array([0.0, 0.0, 0.0, 0.0, TGUESS, FLUX])
+    with pytest.raises(ValueError):
+        fitter.go(obs=mbobs, guess=guess)


### PR DESCRIPTION
Mirrors the updates to the prepsf moments code.  Take in a noise image and use it to provide correct errors even in the presence of stationary correlated noise.