### PR TITLE
Apodize gauss eval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,14 @@
       with the finite diff derivatives, but should otherwise not
       affect the fits in any noticeable way.  The old exp5 is still
       available but no longer aliased to fexp
+    - apodize the fast gaussian evaluations smoothly to zero between
+      chi^2 of 20 and 25 rather than cutting at 25.  The cut made the
+      model step by exp(-12.5) at the boundary, so parameter
+      derivatives picked up a spike wherever a step moved the
+      boundary.  With the apodization the rendered models are twice
+      differentiable in the parameters everywhere; the window costs
+      about a percent in the pixel loop and removes 1.5e-5 of a round
+      gaussian's flux where the cut removed 3.7e-6
 
 ### New features
 

--- a/ngmix/fastexp_nb.py
+++ b/ngmix/fastexp_nb.py
@@ -79,6 +79,12 @@ def _make_smooth_exp_coeffs():
 
 FASTEXP_MAX_CHI2 = 25.0
 
+# gaussian evaluations are apodized rather than cut: apod_window
+# is 1 below FASTEXP_APOD_CHI2 and rolls off smoothly to 0 at
+# FASTEXP_MAX_CHI2
+FASTEXP_APOD_CHI2 = 20.0
+_APOD_IWIDTH = 1.0 / (FASTEXP_MAX_CHI2 - FASTEXP_APOD_CHI2)
+
 # we limit to chi squared of 25, which means an argument of
 # -0.5*25. Use -15 to be safe
 _EXP_IVALS, _EXP_LOOKUP = _make_exp_lookup(
@@ -86,6 +92,47 @@ _EXP_IVALS, _EXP_LOOKUP = _make_exp_lookup(
     maxval=0,
 )
 _EXP_I0 = _EXP_IVALS[0]
+
+
+@njit
+def apod_window(chi2):
+    """
+    smooth apodization window for the chi^2 truncation of gaussian
+    evaluations
+
+    A quintic smoothstep going from 1 at FASTEXP_APOD_CHI2 to 0 at
+    FASTEXP_MAX_CHI2 with zero first and second derivatives at both
+    ends, so an apodized gaussian is C2 in its parameters where the
+    plain truncation has a step at the boundary
+
+    no range checking is done here: only apply the window for chi2
+    in [FASTEXP_APOD_CHI2, FASTEXP_MAX_CHI2]
+
+    Parameters
+    ----------
+    chi2: number
+        the chi^2 argument of the gaussian
+    """
+    u = (FASTEXP_MAX_CHI2 - chi2) * _APOD_IWIDTH
+    return u * u * u * (10.0 + u * (-15.0 + 6.0 * u))
+
+
+@njit
+def apod_window_deriv(chi2):
+    """
+    derivative of apod_window with respect to chi^2
+
+    no range checking is done here: only apply the window for chi2
+    in [FASTEXP_APOD_CHI2, FASTEXP_MAX_CHI2]
+
+    Parameters
+    ----------
+    chi2: number
+        the chi^2 argument of the gaussian
+    """
+    u = (FASTEXP_MAX_CHI2 - chi2) * _APOD_IWIDTH
+    umu = u * (1.0 - u)
+    return -30.0 * umu * umu * _APOD_IWIDTH
 
 
 @njit

--- a/ngmix/fitting/noise_cov.py
+++ b/ngmix/fitting/noise_cov.py
@@ -250,8 +250,8 @@ def _dmodel(fit_model, pars, ipar, band, obs):
         gm = gmix.make_gmix_model(band_pars, fit_model.model)
         if obs.has_psf_gmix():
             gm = gm.convolve(obs.psf.gmix)
-        # the same fast exp and clip as the fdiff renders,
-        # consistent with the fit's objective
+        # the same fast exp and apodized truncation as the fdiff
+        # renders, consistent with the fit's objective
         ims.append(gm.make_image(
             obs.image.shape, jacobian=obs.jacobian,
             fast_exp=True,

--- a/ngmix/fitting/noise_cov_nb.py
+++ b/ngmix/fitting/noise_cov_nb.py
@@ -14,11 +14,20 @@ so the six derivative images cost one pixel pass at a small
 multiple of a single render, replacing the twelve renders of
 the central-difference evaluation.  The flux derivative is the
 value image over the flux and is formed by the caller.
+
+In the apodization band the render carries the window W(chi2),
+and every term that flows through chi^2 picks up the window
+slope as well:
+
+    d [W E] / d p = E (W - 2 W') d(-chi^2/2)/dp
 """
 import numpy as np
 from numba import njit
 
-from ..fastexp_nb import fexp, FASTEXP_MAX_CHI2
+from ..fastexp_nb import (
+    fexp, FASTEXP_MAX_CHI2, FASTEXP_APOD_CHI2,
+    apod_window, apod_window_deriv,
+)
 
 TWO_PI = 2.0 * np.pi
 
@@ -69,16 +78,24 @@ def deriv_images(gpars, dcov, vv, uu, area, out):
             qv = (icc * dv - irc * du) / det
             qu = (-irc * dv + irr * du) / det
             chi2 = dv * qv + du * qu
-            # the same fast exp and clip as the fdiff renders:
-            # the fit's objective is the clipped fastexp model,
-            # so its response derivatives are too
+            # the same fast exp and apodized truncation as the
+            # fdiff renders: the fit's objective is the apodized
+            # fastexp model, so its response derivatives are too
             if chi2 > FASTEXP_MAX_CHI2 or chi2 < 0.0:
                 continue
             val = norm * fexp(-0.5 * chi2)
+            if chi2 > FASTEXP_APOD_CHI2:
+                w = apod_window(chi2)
+                # terms that flow through chi^2 carry the window
+                # slope: d[W E]/dp = E (W - 2 W') d(-chi^2/2)/dp
+                valc = val * (w - 2.0 * apod_window_deriv(chi2))
+                val *= w
+            else:
+                valc = val
 
             out[0, ipix] += val
-            out[1, ipix] += val * qv
-            out[2, ipix] += val * qu
+            out[1, ipix] += valc * qv
+            out[2, ipix] += valc * qu
             for a in range(3):
                 da = dcov[ig, a, 0]
                 db = dcov[ig, a, 1]
@@ -86,4 +103,4 @@ def deriv_images(gpars, dcov, vv, uu, area, out):
                 quad = qv * qv * da + 2.0 * qv * qu * db \
                     + qu * qu * dc
                 tr = (icc * da - 2.0 * irc * db + irr * dc) / det
-                out[3 + a, ipix] += 0.5 * val * (quad - tr)
+                out[3 + a, ipix] += 0.5 * (valc * quad - val * tr)

--- a/ngmix/gmix/gmix_nb.py
+++ b/ngmix/gmix/gmix_nb.py
@@ -1,7 +1,9 @@
 import numpy
 from numpy import array, nan
 from numba import njit
-from ..fastexp_nb import fexp, FASTEXP_MAX_CHI2
+from ..fastexp_nb import (
+    fexp, FASTEXP_MAX_CHI2, FASTEXP_APOD_CHI2, apod_window,
+)
 
 # need to make this a pure python exception
 from ..gexceptions import GMixRangeError
@@ -29,6 +31,11 @@ def gauss2d_eval_pixel_fast(gauss, pixel):
     evaluate a 2-d gaussian at the specified location, using
     the fast exponential
 
+    The evaluation is apodized smoothly to zero between
+    FASTEXP_APOD_CHI2 and FASTEXP_MAX_CHI2 rather than cut, so the
+    value is C2 in the parameters with no step at the truncation
+    boundary
+
     parameters
     ----------
     gauss2d: gauss2d structure
@@ -50,6 +57,8 @@ def gauss2d_eval_pixel_fast(gauss, pixel):
 
     if chi2 < FASTEXP_MAX_CHI2 and chi2 >= 0.0:
         model_val = gauss["pnorm"] * fexp(-0.5 * chi2) * pixel["area"]
+        if chi2 > FASTEXP_APOD_CHI2:
+            model_val *= apod_window(chi2)
 
     return model_val
 

--- a/ngmix/tests/test_fastexp.py
+++ b/ngmix/tests/test_fastexp.py
@@ -59,6 +59,44 @@ def test_fastexp_c2_conditions():
         coeffs = coeffs[1:] * np.arange(1, coeffs.size)
 
 
+def test_apod_window():
+    """
+    the truncation apodization window is 1 at the start of the
+    band, 0 at the end, monotonic, and joins with zero slope at
+    both ends so apodized gaussians are smooth in their parameters
+    """
+    from ngmix.fastexp_nb import (
+        FASTEXP_APOD_CHI2, FASTEXP_MAX_CHI2,
+        apod_window, apod_window_deriv,
+    )
+
+    assert apod_window(FASTEXP_APOD_CHI2) == 1.0
+    assert apod_window(FASTEXP_MAX_CHI2) == 0.0
+    assert apod_window_deriv(FASTEXP_APOD_CHI2) == 0.0
+    assert apod_window_deriv(FASTEXP_MAX_CHI2) == 0.0
+
+    chi2 = np.linspace(
+        FASTEXP_APOD_CHI2, FASTEXP_MAX_CHI2, 1001,
+    )
+    wvals = np.array([apod_window(c) for c in chi2])
+    assert np.all(np.diff(wvals) < 0)
+
+    # the analytic derivative matches central differences
+    eps = 1.0e-6
+    for c in np.linspace(
+        FASTEXP_APOD_CHI2 + 0.1, FASTEXP_MAX_CHI2 - 0.1, 20,
+    ):
+        fd = (apod_window(c + eps) - apod_window(c - eps)) / (2 * eps)
+        assert abs(apod_window_deriv(c) - fd) < 1.0e-8
+
+    # second derivative vanishes at both ends, so the join is C2
+    for c in (FASTEXP_APOD_CHI2, FASTEXP_MAX_CHI2):
+        d2 = (
+            apod_window_deriv(c + eps) - apod_window_deriv(c - eps)
+        ) / (2 * eps)
+        assert abs(d2) < 1.0e-5
+
+
 def test_fastexp_smooth_at_boundaries():
     """
     no steps in the value or first derivative at the half integer

--- a/ngmix/tests/test_fitting_noise_cov.py
+++ b/ngmix/tests/test_fitting_noise_cov.py
@@ -34,42 +34,6 @@ def _smooth(im, kernel):
     return fftconvolve(im, kernel, mode='same')
 
 
-def _off_clip_ring(fit_model, pars, band, obs, margin=0.2):
-    """
-    mask of pixels away from the chi^2 = FASTEXP_MAX_CHI2
-    truncation boundary of every composed gaussian.  The
-    central-difference reference renders the clipped model, so it
-    differentiates the migrating truncation boundary; that is a
-    property of the clipped objective, not of the derivative
-    approximation under test.  The fd steps move the rings by
-    |dchi2| < 0.03, well inside the margin
-    """
-    from ngmix.fastexp_nb import FASTEXP_MAX_CHI2
-
-    band_pars = fit_model.get_band_pars(pars=pars, band=band)
-    gm = ngmix.gmix.make_gmix_model(band_pars, fit_model.model)
-    if obs.has_psf_gmix():
-        gm = gm.convolve(obs.psf.gmix)
-    gpars = gm.get_full_pars().reshape(-1, 6)
-
-    dims = obs.image.shape
-    rows, cols = np.mgrid[0:dims[0], 0:dims[1]]
-    vv, uu = obs.jacobian.get_vu(
-        row=rows.ravel().astype('f8'),
-        col=cols.ravel().astype('f8'),
-    )
-    off = np.ones(vv.size, dtype=bool)
-    for _, vc, uc, irr, irc, icc in gpars:
-        det = irr * icc - irc * irc
-        dv = vv - vc
-        du = uu - uc
-        chi2 = (
-            icc * dv ** 2 - 2 * irc * dv * du + irr * du ** 2
-        ) / det
-        off &= np.abs(chi2 - FASTEXP_MAX_CHI2) > margin
-    return off.reshape(dims)
-
-
 def _make_obs(rng, sigma, kernel=None, nband=1, with_noise=True):
     import galsim
 
@@ -281,21 +245,16 @@ def test_noise_cov_analytic_vs_fd(model):
             # would mean the analytic branch silently fell
             # back to the finite differences
             assert not np.array_equal(ana[0], ref[0])
-            # compare away from the chi^2 truncation rings of
-            # the composed gaussians, which the differences
-            # differentiate (see _off_clip_ring).  With the
-            # smooth fexp the only remaining differences are
-            # its derivative approximation (~3e-5 relative)
-            # and the fd truncation error
-            off_ring = _off_clip_ring(
-                fit_model=fit_model, pars=pars, band=band,
-                obs=obs,
-            )
+            # the apodized truncation and smooth fexp make the
+            # model C2 in the parameters everywhere, so every
+            # pixel is compared, including the former clip
+            # boundary.  The remaining differences are the fexp
+            # derivative approximation (~3e-5 relative) and the
+            # fd truncation error
             for a, r in zip(ana, ref):
                 scale = np.abs(r).max()
                 assert np.allclose(
-                    a[off_ring], r[off_ring],
-                    atol=1.0e-4 * scale,
+                    a, r, atol=1.0e-4 * scale,
                 )
 
     cov = calc_noise_cov(
@@ -313,13 +272,13 @@ def test_noise_cov_analytic_vs_fd(model):
         noise_cov._ANALYTIC_MODELS = saved
     assert np.allclose(
         np.sqrt(np.diag(cov)), np.sqrt(np.diag(ref)),
-        rtol=2.0e-4,
+        rtol=5.0e-5,
     )
     # off-diagonal deviations measured against the error scale:
     # elementwise relative tolerances blow up on the near-zero
     # correlation elements
     escale = np.sqrt(np.outer(np.diag(ref), np.diag(ref)))
-    assert np.all(np.abs(cov - ref) < 4.0e-4 * escale)
+    assert np.all(np.abs(cov - ref) < 1.0e-4 * escale)
 
 
 def test_noise_cov_requires_noise():


### PR DESCRIPTION
apodize the fast gaussian evaluations smoothly to zero between chi^2 of
    20 and 25 rather than cutting at 25.  The cut made the model step by
    exp(-12.5) at the boundary, so parameter derivatives picked up a spike
    wherever a step moved the boundary.  With the apodization the rendered
    models are twice differentiable in the parameters everywhere; the window
    costs about a percent in the pixel loop and removes 1.5e-5 of a round
    gaussian's flux where the cut removed 3.7e-6